### PR TITLE
fix: 一部ユーザーで報告機能が動作しない問題を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: '作成するタグ名 (例: v1.0.0.0)'
+        required: true
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # 一旦、履歴をすべて取得する
+
+      - name: Create ZIP File
+        run: |
+          # 念の為、実行権限を与えておく
+          chmod +x ./package.sh
+          ./package.sh
+
+      - name: Fetch Latest Merged PR Infomation
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # 最新のマージ済みPRのタイトルと本文を取得して書き出す
+          # 最新の1件を取得
+          gh pr list --state merged --limit 1 --json title,body --template \
+            '# {{.title}}{{"\n\n"}}{{.body}}' > release_notes.md
+
+      - name: Create Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.event.inputs.tag_name }}
+        run: |
+          gh release create "$TAG_NAME" \
+            ./package/*.zip \
+            --title "Release $TAG_NAME" \
+            --notes-file release_notes.md \
+            --draft

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# パッケージディレクトリを除外する
+package_tmp/*
+package/*

--- a/content.js
+++ b/content.js
@@ -2479,7 +2479,6 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
             let report_finalize = false;
             let user_choice = report_mode_conv;
             let choice_convert_flag = false;
-            let is_simple_option = false;
             
             send_srv(response_obj);
             function send_srv(input_response) {
@@ -2510,7 +2509,7 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
                 if (now_steps == 1) {
                     //新しい報告種別「SimpleOption」に対応させる(これはスパム報告が最初に上がっているかどうかで判定させている)
                     if(input_response.subtasks[0].choice_selection.choices[0].id === "SpamSimpleOption"){
-                        const simple_option_map = [1, 1, 3, null, null, null, 0, null, 1, null, 1, null]
+                        const simple_option_map = [1, 1, 3, null, null, null, 0, null, 1, null, 1, null];
                         report_second_stage_body = `{\"flow_token\":\"${input_token_convert}\",\"subtask_inputs\":[{\"subtask_id\":\"single-selection\",\"choice_selection\":{\"link\":\"next_link\",\"selected_choices\":[\"${input_response.subtasks[0].choice_selection.choices[simple_option_map[user_choice]].id}\"]}}]}`;
                     }else{
                         report_second_stage_body = `{\"flow_token\":\"${input_token_convert}\",\"subtask_inputs\":[{\"subtask_id\":\"single-selection\",\"choice_selection\":{\"link\":\"next_link\",\"selected_choices\":[\"${input_response.subtasks[0].choice_selection.choices[user_choice].id}\"]}}]}`;

--- a/content.js
+++ b/content.js
@@ -2479,6 +2479,7 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
             let report_finalize = false;
             let user_choice = report_mode_conv;
             let choice_convert_flag = false;
+            let is_simple_option = false;
             
             send_srv(response_obj);
             function send_srv(input_response) {
@@ -2507,7 +2508,13 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
                     }
                 }
                 if (now_steps == 1) {
-                    report_second_stage_body = `{\"flow_token\":\"${input_token_convert}\",\"subtask_inputs\":[{\"subtask_id\":\"single-selection\",\"choice_selection\":{\"link\":\"next_link\",\"selected_choices\":[\"${input_response.subtasks[0].choice_selection.choices[user_choice].id}\"]}}]}`;
+                    //新しい報告種別「SimpleOption」に対応させる(これはスパム報告が最初に上がっているかどうかで判定させている)
+                    if(input_response.subtasks[0].choice_selection.choices[0].id === "SpamSimpleOption"){
+                        const simple_option_map = [1, 1, 3, null, null, null, 0, null, 1, null, 1, null]
+                        report_second_stage_body = `{\"flow_token\":\"${input_token_convert}\",\"subtask_inputs\":[{\"subtask_id\":\"single-selection\",\"choice_selection\":{\"link\":\"next_link\",\"selected_choices\":[\"${input_response.subtasks[0].choice_selection.choices[simple_option_map[user_choice]].id}\"]}}]}`;
+                    }else{
+                        report_second_stage_body = `{\"flow_token\":\"${input_token_convert}\",\"subtask_inputs\":[{\"subtask_id\":\"single-selection\",\"choice_selection\":{\"link\":\"next_link\",\"selected_choices\":[\"${input_response.subtasks[0].choice_selection.choices[user_choice].id}\"]}}]}`;
+                    }
                 } else {
                     if (report_finalize != true && user_choice != 6) {
                         //報告種別が10種類のものもあれば、11種類のものもあるので、センシティブの項目を判別してマップを切り替える

--- a/content.js
+++ b/content.js
@@ -346,7 +346,7 @@ function main(filter_url, imp_filter_url) {
                     oneclick_report_timeline_disable: false,
                     oneclick_report_target_mode: "0",
                     oneclick_report_after_mode: "0",
-                    oneclick_report_option: "5",
+                    oneclick_report_option: "6",
                     oneclick_report_notification_page_disable: false,
                     oneclick_report_add_cslt_hideuser: false,
                     oneclick_developer_report: false,

--- a/content.js
+++ b/content.js
@@ -2484,10 +2484,25 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
             function send_srv(input_response) {
                 const input_token_convert = decodeURIComponent(input_response.flow_token).replaceAll("=", "");
                 let report_second_stage_body = null;
-                if(!choice_convert_flag && now_steps === 1 &&input_response.subtasks[0].choice_selection?.choices[8]?.id !== "ShownSensitiveDisturbingMediaOption"){
+                if(!choice_convert_flag && now_steps === 1 && input_response.subtasks[0].choice_selection?.choices[8]?.id !== "ShownSensitiveDisturbingMediaOption"){
                     if(user_choice === 8){
+                        //この条件が古くなっている可能性があるが、ページンによって項目が変わってくる仕様のため、念の為残しておく
                         //ステップ1の項目が10種類の場合、「攻撃的な行為や嫌がらせ」にセンシティブが含まれているので切り替える
                         user_choice = 1;
+                        choice_convert_flag = true;
+                    }
+                }
+                if(!choice_convert_flag && now_steps === 1 && input_response.subtasks[0].choice_selection?.choices[8]?.id === "DeceptiveIdentitiesOption"){
+                    if(user_choice === 8){
+                        //ステップ1の項目の8番目が「なりすまし」になっている場合、センシティブの項目が存在しないため「攻撃的な行為や嫌がらせ」に切り替える
+                        user_choice = 1;
+                        choice_convert_flag = true;
+                    }
+                }
+                if(!choice_convert_flag && now_steps === 1 && input_response.subtasks[0].choice_selection?.choices[10]?.id === "CivicIntegrityOption"){
+                    if(user_choice === 10){
+                        //ユーザーページなどでステップ1の項目が11種類の場合、「暴力行為やヘイト行為の主体」が9番目にあるので切り替える
+                        user_choice = 9;
                         choice_convert_flag = true;
                     }
                 }

--- a/content.js
+++ b/content.js
@@ -2509,11 +2509,12 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
                 if (now_steps == 1) {
                     report_second_stage_body = `{\"flow_token\":\"${input_token_convert}\",\"subtask_inputs\":[{\"subtask_id\":\"single-selection\",\"choice_selection\":{\"link\":\"next_link\",\"selected_choices\":[\"${input_response.subtasks[0].choice_selection.choices[user_choice].id}\"]}}]}`;
                 } else {
-                    if (report_finalize != true) {
+                    if (report_finalize != true && user_choice != 6) {
                         //報告種別が10種類のものもあれば、11種類のものもあるので、センシティブの項目を判別してマップを切り替える
+                        //報告種別が「スパム」では第二ステップの選択肢はないのでパスする
                         let choice_def = [];
                         if(!choice_convert_flag){
-                            choice_def = [4, 5, 2, null, null, null, null, null, 0, null, null];
+                            choice_def = [4, 5, 2, null, null, null, null, null, 0, null, null, null];
                         }else{
                             choice_def = [4, 0, 2, null, null, null, null, null, null, null];
                         }

--- a/cslt_tweet_ctrl.js
+++ b/cslt_tweet_ctrl.js
@@ -22,7 +22,7 @@ function get_tw_userdata(input_element, mode){
         case "settings_block_mute_user_id":
             return props_data?.children[0][1]?.props?.children[0]?.props?.children[1]?.props?.userId;
         case "notification_like_rt":
-            return props_data?.children[0][1]?.props?.children[0]?.props?.children?.props?.users;
+            return props_data?.children[0][1]?.props?.children?.props?.children[0]?.props?.children?.props?.users
     }
 }
 const root_elem = document.querySelector('#react-root');

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Clean-Spam-Link-Tweet",
-  "version": "1.9.9.0",
+  "version": "1.9.9.1",
   "manifest_version": 3,
   "description": "ツイート(返信)から悪質なリンクが記載されたツイートを可視化してナイト系スパム等のリンクを踏む事を阻止します。",
   "icons" : {

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -1,0 +1,43 @@
+{
+  "name": "Clean-Spam-Link-Tweet",
+  "version": "1.9.9.1",
+  "manifest_version": 2,
+  "description": "ツイート(返信)から悪質なリンクが記載されたツイートを可視化してナイト系スパム等のリンクを踏む事を阻止します。",
+  "icons" : {
+    "128" : "icon.png"
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "kwnobu@gmail.com",
+      "strict_min_version": "113.0"
+    },
+    "gecko_android": {
+      "id": "kwnobu@gmail.com",
+      "strict_min_version": "113.0"
+    }
+  },
+  "browser_action": {
+    "default_popup": "popup.html",
+    "default_icon": "icon.png"
+  },
+  "web_accessible_resources": [
+    "cslt_tweet_ctrl.js",
+    "filter.json",
+    "imp_filter.json",
+    "report_icon.svg",
+    "report_fail_icon.svg"
+  ],
+  "background" : {
+    "scripts": ["background.js"]
+  },
+  "permissions" : [
+    "storage",
+    "cookies",
+    "<all_urls>"
+  ],
+  "content_scripts": [{
+    "matches": ["https://twitter.com/*", "https://x.com/*"],
+    "js": ["content.js"],
+    "all_frames": true
+    }]
+  }

--- a/package.ps1
+++ b/package.ps1
@@ -1,0 +1,103 @@
+$ErrorActionPreference = "Stop"
+
+# 設定
+$TargetDir = "."
+$TmpDir = Join-Path $TargetDir "package_tmp"
+$OutputDir = Join-Path $TargetDir "package"
+
+# バージョン取得
+function Get-Version {
+    $manifestPath = $null
+    if (Test-Path (Join-Path $TargetDir "manifest.json")) {
+        $manifestPath = Join-Path $TargetDir "manifest.json"
+    } elseif (Test-Path (Join-Path $TargetDir "manifest_firefox.json")) {
+        $manifestPath = Join-Path $TargetDir "manifest_firefox.json"
+    } else {
+        return "0_0_0"
+    }
+
+    $json = Get-Content $manifestPath -Raw | ConvertFrom-Json
+    if (-not $json.version) { return "0_0_0" }
+    return ($json.version.ToString() -replace '\.', '_')
+}
+
+$Version = Get-Version
+Write-Host "version: $Version"
+
+$ZipFirefox = "CSLT_Firefox_${Version}.zip"
+$ZipChrome  = "CSLT_Chromium_${Version}.zip"
+
+# 初期化
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+Remove-Item -Recurse -Force -ErrorAction Ignore $TmpDir
+New-Item -ItemType Directory -Force -Path $TmpDir | Out-Null
+
+# フォルダ除外
+$ExcludeDirs = @(
+    ".git",
+    "package_tmp",
+    "package",
+    "node_modules"
+)
+
+# ファイル除外
+$ExcludeFiles = @(
+    ".gitignore",
+    "README.md",
+    ".DS_Store",
+    "*.sh",
+    "*.ps1"
+)
+
+function Invoke-RoboCopy {
+    param(
+        [Parameter(Mandatory=$true)][string]$Source,
+        [Parameter(Mandatory=$true)][string]$Dest,
+        [string[]]$XD,
+        [string[]]$XF
+    )
+
+    $args = @(
+        $Source, $Dest,
+        "/E", "/R:0", "/W:0",
+        "/NFL", "/NDL", "/NJH", "/NJS"
+    )
+
+    if ($XD -and $XD.Count -gt 0) { $args += "/XD"; $args += $XD }
+    if ($XF -and $XF.Count -gt 0) { $args += "/XF"; $args += $XF }
+
+    $null = & robocopy @args
+
+    if ($LASTEXITCODE -ge 8) {
+        throw "robocopy に失敗しました $LASTEXITCODE"
+    }
+}
+
+# Firefox 用 ZIP 作成
+Invoke-RoboCopy -Source $TargetDir -Dest $TmpDir -XD $ExcludeDirs -XF $ExcludeFiles
+
+$ffManifest = Join-Path $TmpDir "manifest_firefox.json"
+$mainManifest = Join-Path $TmpDir "manifest.json"
+if (Test-Path $ffManifest) {
+    Move-Item $ffManifest $mainManifest -Force
+}
+
+$ffZipPath = Join-Path $OutputDir $ZipFirefox
+if (Test-Path $ffZipPath) { Remove-Item -Force $ffZipPath }
+Compress-Archive -Path (Join-Path $TmpDir "*") -DestinationPath $ffZipPath -Force
+
+Remove-Item -Recurse -Force $TmpDir
+New-Item -ItemType Directory -Force -Path $TmpDir | Out-Null
+
+# Chrome 用 ZIP 作成
+Invoke-RoboCopy -Source $TargetDir -Dest $TmpDir -XD $ExcludeDirs -XF ($ExcludeFiles + @("manifest_firefox.json"))
+
+$chZipPath = Join-Path $OutputDir $ZipChrome
+if (Test-Path $chZipPath) { Remove-Item -Force $chZipPath }
+Compress-Archive -Path (Join-Path $TmpDir "*") -DestinationPath $chZipPath -Force
+
+Remove-Item -Recurse -Force $TmpDir
+
+Write-Host "ZIP圧縮が完了しました:"
+Write-Host " - Firefox版: $ffZipPath"
+Write-Host " - Chrome版:  $chZipPath"

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euo pipefail
+
+# 設定
+TARGET_DIR="."
+TMP_DIR="./package_tmp"
+OUTPUT_DIR="./package"
+
+# バージョン番号を manifest から取得
+get_version() {
+    local manifest_file=""
+    if [ -f "$TARGET_DIR/manifest.json" ]; then
+        manifest_file="$TARGET_DIR/manifest.json"
+    elif [ -f "$TARGET_DIR/manifest_firefox.json" ]; then
+        manifest_file="$TARGET_DIR/manifest_firefox.json"
+    else
+        echo "0.0.0"
+        return
+    fi
+
+    # バージョン情報を抽出
+    grep -oE '"version"\s*:\s*"[^"]+"' "$manifest_file" | sed -E 's/.*"([^"]+)"/\1/' | tr '.' '_' || echo "0_0_0"
+}
+
+VERSION="$(get_version)"
+echo "version: $VERSION"
+
+ZIP_FIREFOX="CSLT_Firefox_${VERSION}.zip"
+ZIP_CHROME="CSLT_Chromium_${VERSION}.zip"
+
+# 初期化
+mkdir -p "$OUTPUT_DIR"
+rm -rf "$TMP_DIR"
+mkdir -p "$TMP_DIR"
+
+# 除外ルール
+RSYNC_EXCLUDES=(
+  --exclude=".git"
+  --exclude=".gitignore"
+  --exclude="README.md"
+  --exclude=".DS_Store"
+  --exclude="package_tmp"
+  --exclude="package"
+  --exclude="*.sh"
+  --exclude="*.ps1"
+)
+
+# Firefox 用 ZIP
+rsync -av "${RSYNC_EXCLUDES[@]}" "$TARGET_DIR/" "$TMP_DIR/"
+if [ -f "$TMP_DIR/manifest_firefox.json" ]; then
+    mv "$TMP_DIR/manifest_firefox.json" "$TMP_DIR/manifest.json"
+fi
+(cd "$TMP_DIR" && zip -r "../$OUTPUT_DIR/$ZIP_FIREFOX" .)
+rm -rf "$TMP_DIR"
+
+# Chrome 用 ZIP
+mkdir -p "$TMP_DIR"
+rsync -av "${RSYNC_EXCLUDES[@]}" --exclude="manifest_firefox.json" "$TARGET_DIR/" "$TMP_DIR/"
+(cd "$TMP_DIR" && zip -r "../$OUTPUT_DIR/$ZIP_CHROME" .)
+rm -rf "$TMP_DIR"
+
+echo "ZIP圧縮が完了しました:"
+echo " - Firefox版: $OUTPUT_DIR/$ZIP_FIREFOX"
+echo " - Chrome版:  $OUTPUT_DIR/$ZIP_CHROME"

--- a/popup.css
+++ b/popup.css
@@ -21,6 +21,9 @@ select{
 hr{
   margin: 0;
 }
+option[disabled] {
+  display: none;
+}
 .main{
   display: flex;
   flex-direction: column;

--- a/popup.css
+++ b/popup.css
@@ -390,6 +390,11 @@ input:checked + label:after {
     display: flex;
     justify-content: center;
   }
+  #debug_info_dump_sw {
+    margin-top: 30px;
+    font-size: 3rem;
+    width: 50%;
+  }
   #settings_reset_sw {
     margin-top: 30px;
     font-size: 3rem;

--- a/popup.html
+++ b/popup.html
@@ -452,6 +452,7 @@
                         <option value="8" title="センシティブ・不安にさせる内容として報告">センシティブなメディア</option>
                         <option value="9" title="無効な項目" disabled></option>
                         <option value="10" title="過激的主義・団体への関与">暴力的行為やヘイト行為の主体</option>
+                        <option value="11" title="無効な項目" disabled></option>
                     </select>
                 </div>
             </div>


### PR DESCRIPTION
## 追加されたもの
- リリース用ZIP生成スクリプトを用意
  - Windows環境でZIPを作成できるようにした
  - bash環境でも生成できるようにした
- Github Actionsを使ってリリースを作成できるようにした 

## 直したもの
- ワンクリック報告機能
  - 新しい報告UIに切り替わっているユーザーで報告機能が動作しない問題を修正
  - 従来の報告UIに追加された報告種別の動作やマッピングを追加した
  - 通知欄で報告ボタンが出現しない問題を修正
- 設定画面
  - Android 環境で環境情報コピーボタンが極端に小さい問題を修正
  - 報告種別が無効化されているものが初期で選択されている問題を修正
  - 無効化されたセレクトボックスの項目を表示しないようにした 

## 動作確認
- [x] Firefox系のブラウザでも問題なく動作するか


## その他の変更
Firefox版と`manifest.json`以外はすべてコードの共通化が行われているため、
今回からメインはリリースブランチ一本で運用する事とした。

## 雑記(あればご自由にどうぞ)
いっぱい修正しました！

## マージ後の CSLT バージョン
- 1.9.9.1