### PR TITLE
fix: 報告機能(種別選択&ボタン表示)を修正

### DIFF
--- a/content.js
+++ b/content.js
@@ -2524,26 +2524,30 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
             function send_srv(input_response) {
                 const input_token_convert = decodeURIComponent(input_response.flow_token).replaceAll("=", "");
                 let report_second_stage_body = null;
-                if(!choice_convert_flag && now_steps === 1 && input_response.subtasks[0].choice_selection?.choices[8]?.id !== "ShownSensitiveDisturbingMediaOption"){
-                    if(user_choice === 8){
-                        //この条件が古くなっている可能性があるが、ページンによって項目が変わってくる仕様のため、念の為残しておく
-                        //ステップ1の項目が10種類の場合、「攻撃的な行為や嫌がらせ」にセンシティブが含まれているので切り替える
-                        user_choice = 1;
-                        choice_convert_flag = true;
+
+                //旧報告UI向けのオプションをフォールバックする
+                if(now_steps === 1 && input_response.subtasks[0].choice_selection.choices[0].id !== "SpamSimpleOption"){
+                    if(!choice_convert_flag && now_steps === 1 && input_response.subtasks[0].choice_selection?.choices[8]?.id !== "ShownSensitiveDisturbingMediaOption"){
+                        if(user_choice === 8){
+                            //この条件が古くなっている可能性があるが、ページによって項目が変わってくる仕様のため、念の為残しておく
+                            //ステップ1の項目が10種類の場合、「攻撃的な行為や嫌がらせ」にセンシティブが含まれているので切り替える
+                            user_choice = 1;
+                            choice_convert_flag = true;
+                        }
                     }
-                }
-                if(!choice_convert_flag && now_steps === 1 && input_response.subtasks[0].choice_selection?.choices[8]?.id === "DeceptiveIdentitiesOption"){
-                    if(user_choice === 8){
-                        //ステップ1の項目の8番目が「なりすまし」になっている場合、センシティブの項目が存在しないため「攻撃的な行為や嫌がらせ」に切り替える
-                        user_choice = 1;
-                        choice_convert_flag = true;
+                    if(!choice_convert_flag && now_steps === 1 && input_response.subtasks[0].choice_selection?.choices[8]?.id === "DeceptiveIdentitiesOption"){
+                        if(user_choice === 8){
+                            //ステップ1の項目の8番目が「なりすまし」になっている場合、センシティブの項目が存在しないため「攻撃的な行為や嫌がらせ」に切り替える
+                            user_choice = 1;
+                            choice_convert_flag = true;
+                        }
                     }
-                }
-                if(!choice_convert_flag && now_steps === 1 && input_response.subtasks[0].choice_selection?.choices[10]?.id === "CivicIntegrityOption"){
-                    if(user_choice === 10){
-                        //ユーザーページなどでステップ1の項目が11種類の場合、「暴力行為やヘイト行為の主体」が9番目にあるので切り替える
-                        user_choice = 9;
-                        choice_convert_flag = true;
+                    if(!choice_convert_flag && now_steps === 1 && input_response.subtasks[0].choice_selection?.choices[10]?.id === "CivicIntegrityOption"){
+                        if(user_choice === 10){
+                            //ユーザーページなどでステップ1の項目が11種類の場合、「暴力行為やヘイト行為の主体」が9番目にあるので切り替える
+                            user_choice = 9;
+                            choice_convert_flag = true;
+                        }
                     }
                 }
                 if (now_steps == 1) {
@@ -2552,15 +2556,15 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
                         const simple_option_map = [
                           "HateOrAbuseSimpleOption",
                           "HateOrAbuseSimpleOption",
-                          "ViolentSpeechSimpleOption",
+                          "TerrorismSimpleOption",
                           null,
                           null,
                           null,
                           "SpamSimpleOption",
                           null,
-                          "HateOrAbuseSimpleOption",
+                          "ViolentMediaSimpleOption",
                           null,
-                          "HateOrAbuseSimpleOption",
+                          "ViolentSpeechSimpleOption",
                           null,
                         ];
                         report_second_stage_body = `{\"flow_token\":\"${input_token_convert}\",\"subtask_inputs\":[{\"subtask_id\":\"single-selection\",\"choice_selection\":{\"link\":\"next_link\",\"selected_choices\":[\"${simple_option_map[user_choice]}\"]}}]}`;
@@ -2569,9 +2573,11 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
                     }
                 } else {
                     if (report_finalize != true && user_choice != 6) {
+                        //主に旧報告UI向け。新UIでは進捗100%になるため、ここはスルーされる
                         //報告種別が10種類のものもあれば、11種類のものもあるので、センシティブの項目を判別してマップを切り替える
                         //報告種別が「スパム」では第二ステップの選択肢はないのでパスする
                         let choice_def = [];
+                        //第2ステップの選択項目
                         if(!choice_convert_flag){
                             choice_def = [4, 5, 2, null, null, null, null, null, 0, null, null, null];
                         }else{
@@ -2579,6 +2585,7 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
                         }
                         report_second_stage_body = `{\"flow_token\":\"${input_token_convert}\",\"subtask_inputs\":[{\"subtask_id\":\"single-selection\",\"choice_selection\":{\"link\":\"next_link\",\"selected_choices\":[\"${input_response.subtasks[0].choice_selection.choices[choice_def[user_choice]].id}\"]}}]}`;
                     } else {
+                        //進捗100%の場合など、一連のフローが終了したということを送信する
                         report_second_stage_body = `{\"flow_token\":\"${input_token_convert}\",\"subtask_inputs\":[{\"subtask_id\":\"${input_response.subtasks[0].subtask_id}\",\"settings_list\":{\"setting_responses\":[],\"link\":\"next_link\"}}]}`;
                     }
                 }

--- a/content.js
+++ b/content.js
@@ -2637,7 +2637,12 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
                     }
                 }).catch(error => {
                     console.log("Report 2nd stage error");
-                    cslt_message_display(`通報の${now_steps}ステップ目失敗(${error.message})`, "error");
+                    //連続報告を行った際に発生するエラーを判定する
+                    if(now_steps === 2 && error.message.includes("(reading 'subtasks')")){
+                        cslt_message_display(`通報の${now_steps}ステップ目失敗(連続報告により一時的に制限された可能性)`, "error");
+                    }else{
+                        cslt_message_display(`通報の${now_steps}ステップ目失敗(${error.message})`, "error");
+                    }
                     report_ids_temp(report_twid, "fail_report");
                     console.log(error);
                 });

--- a/content.js
+++ b/content.js
@@ -2553,6 +2553,8 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
                 if (now_steps == 1) {
                     //新しい報告種別「SimpleOption」に対応させる(これはスパム報告が最初に上がっているかどうかで判定させている)
                     if(input_response.subtasks[0].choice_selection.choices[0].id === "SpamSimpleOption"){
+                        //新UI報告オプション
+                        let report_type = "SpamSimpleOption";
                         const simple_option_map = [
                           "HateOrAbuseSimpleOption",
                           "HateOrAbuseSimpleOption",
@@ -2567,7 +2569,14 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
                           "ViolentSpeechSimpleOption",
                           null,
                         ];
-                        report_second_stage_body = `{\"flow_token\":\"${input_token_convert}\",\"subtask_inputs\":[{\"subtask_id\":\"single-selection\",\"choice_selection\":{\"link\":\"next_link\",\"selected_choices\":[\"${simple_option_map[user_choice]}\"]}}]}`;
+                        //指定された報告種別がない場合はスパム報告にフォールバックする
+                        //特にユーザーページで ViolentMediaSimpleOption が選択できない事が多い
+                        if(input_response.subtasks[0].choice_selection.choices.some(option => option.id === simple_option_map[user_choice])){
+                            report_type = simple_option_map[user_choice];
+                        }else{
+                            cslt_message_display('設定された報告種別を選択できませんでした。スパムとして報告を行います', "message");
+                        }
+                        report_second_stage_body = `{\"flow_token\":\"${input_token_convert}\",\"subtask_inputs\":[{\"subtask_id\":\"single-selection\",\"choice_selection\":{\"link\":\"next_link\",\"selected_choices\":[\"${report_type}\"]}}]}`;
                     }else{
                         report_second_stage_body = `{\"flow_token\":\"${input_token_convert}\",\"subtask_inputs\":[{\"subtask_id\":\"single-selection\",\"choice_selection\":{\"link\":\"next_link\",\"selected_choices\":[\"${input_response.subtasks[0].choice_selection.choices[user_choice].id}\"]}}]}`;
                     }

--- a/content.js
+++ b/content.js
@@ -2549,8 +2549,21 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
                 if (now_steps == 1) {
                     //新しい報告種別「SimpleOption」に対応させる(これはスパム報告が最初に上がっているかどうかで判定させている)
                     if(input_response.subtasks[0].choice_selection.choices[0].id === "SpamSimpleOption"){
-                        const simple_option_map = [1, 1, 3, null, null, null, 0, null, 1, null, 1, null];
-                        report_second_stage_body = `{\"flow_token\":\"${input_token_convert}\",\"subtask_inputs\":[{\"subtask_id\":\"single-selection\",\"choice_selection\":{\"link\":\"next_link\",\"selected_choices\":[\"${input_response.subtasks[0].choice_selection.choices[simple_option_map[user_choice]].id}\"]}}]}`;
+                        const simple_option_map = [
+                          "HateOrAbuseSimpleOption",
+                          "HateOrAbuseSimpleOption",
+                          "ViolentSpeechSimpleOption",
+                          null,
+                          null,
+                          null,
+                          "SpamSimpleOption",
+                          null,
+                          "HateOrAbuseSimpleOption",
+                          null,
+                          "HateOrAbuseSimpleOption",
+                          null,
+                        ];
+                        report_second_stage_body = `{\"flow_token\":\"${input_token_convert}\",\"subtask_inputs\":[{\"subtask_id\":\"single-selection\",\"choice_selection\":{\"link\":\"next_link\",\"selected_choices\":[\"${simple_option_map[user_choice]}\"]}}]}`;
                     }else{
                         report_second_stage_body = `{\"flow_token\":\"${input_token_convert}\",\"subtask_inputs\":[{\"subtask_id\":\"single-selection\",\"choice_selection\":{\"link\":\"next_link\",\"selected_choices\":[\"${input_response.subtasks[0].choice_selection.choices[user_choice].id}\"]}}]}`;
                     }

--- a/content.js
+++ b/content.js
@@ -652,7 +652,7 @@ function main(filter_url, imp_filter_url) {
                 /* ページ検出関連関数 */
                 //タイムライン検出用
                 function is_timeline_follow() {
-                    const tl_tab_elem = document.querySelectorAll('div[data-testid="ScrollSnap-List"] div[role="presentation"] a[role="tab"]');
+                    const tl_tab_elem = document.querySelectorAll('div[data-testid="ScrollSnap-List"] div[role="tab"]');
                     if (tl_tab_elem[1]?.getAttribute('aria-selected') != undefined) {
                         if (window.location.pathname.match("\/home")?.length == 1 && tl_tab_elem[1]?.getAttribute('aria-selected') == "true") {
                             return true;
@@ -697,7 +697,7 @@ function main(filter_url, imp_filter_url) {
                 }
                 //報告用タイムライン検出関数
                 function is_timeline_follow_report() {
-                    if (cslp_settings.oneclick_report_timeline_disable == true && window.location.pathname.match("\/home")?.length == 1 && document.querySelectorAll('div[data-testid="ScrollSnap-List"] div[role="presentation"] a[role="tab"]')[1]?.getAttribute('aria-selected') == "true") {
+                    if (cslp_settings.oneclick_report_timeline_disable == true && window.location.pathname.match("\/home")?.length == 1 && document.querySelectorAll('div[data-testid="ScrollSnap-List"] div[role="tab"]')[1]?.getAttribute('aria-selected') == "true") {
                         return true;
                     } else {
                         return false;

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Clean-Spam-Link-Tweet",
-  "version": "1.9.9.2",
+  "version": "1.9.9.3",
   "manifest_version": 3,
   "description": "ツイート(返信)から悪質なリンクが記載されたツイートを可視化してナイト系スパム等のリンクを踏む事を阻止します。",
   "icons" : {

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -1,6 +1,6 @@
 {
   "name": "Clean-Spam-Link-Tweet",
-  "version": "1.9.9.2",
+  "version": "1.9.9.3",
   "manifest_version": 2,
   "description": "ツイート(返信)から悪質なリンクが記載されたツイートを可視化してナイト系スパム等のリンクを踏む事を阻止します。",
   "icons" : {


### PR DESCRIPTION
## 追加されたもの
なし

## 直したもの
- 報告機能
  - 「TL(フォロー中)報告ボタン非表示」が動作しない問題を修正
    - #26
  - 報告モード周り
    - 一部の環境で正しい報告項目で報告できない問題を修正
      - スパムとして報告できない現象があった
    - 新報告UIの報告項目に追従させた
    - 連続報告などで一時的に報告制限を受けている可能性がある場合に通知を表示するようにした
    - ユーザーページなどで一部選択できない報告オプションに対して別オプションへフォールバックするようにした
      - 特に「露骨なメディアまたは暴力的なメディア」(センシティブなメディア)などが対象

## 動作確認
<!--
動作確認をした項目を記載する
-->
- [x] Firefox系のブラウザでも問題なく動作するか
  - Floorp (FireFox: 149.0.3) で動作を確認

## その他の変更
なし

## マージ後の CSLT バージョン
- `1.9.9.3`

## 雑記(あればご自由にどうぞ)
今回は報告機能の修正を中心に、Twitter側の仕様変更に合わせて追従しました！

特に、設定された報告種別で報告できなかった場合、
「スパム」として設定を切り替えて報告するように動作を改善しました！

#### 作業の時に聞いていた楽曲(覚えている限り)
- 甲賀忍法帖  - 陰陽座
  - https://www.youtube.com/watch?v=v86m2RdPSo8
  - ギターソロすごく格好良いんですよ。
- 時の魔法 - 小木曽雪菜(CV:米澤 円)
  - https://www.youtube.com/watch?v=nPpETwV4bsg


