### PR TITLE
fix: 設定されたものと違う報告オプションで報告される問題を修正

### DIFF
--- a/content.js
+++ b/content.js
@@ -2551,8 +2551,8 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
                     }
                 }
                 if (now_steps == 1) {
-                    //新しい報告種別「SimpleOption」に対応させる(これはスパム報告が最初に上がっているかどうかで判定させている)
-                    if(input_response.subtasks[0].choice_selection.choices[0].id === "SpamSimpleOption"){
+                    //新しい報告種別「SimpleOption」に対応させる
+                    if(input_response.subtasks[0].choice_selection.choices.some(option => option.id === "SpamSimpleOption")){
                         //新UI報告オプション
                         let report_type = "SpamSimpleOption";
                         const simple_option_map = [

--- a/content.js
+++ b/content.js
@@ -2526,7 +2526,7 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
                 let report_second_stage_body = null;
 
                 //旧報告UI向けのオプションをフォールバックする
-                if(now_steps === 1 && input_response.subtasks[0].choice_selection.choices[0].id !== "SpamSimpleOption"){
+                if(now_steps === 1 && !input_response.subtasks[0].choice_selection.choices.some(option => option.id === "SpamSimpleOption")){
                     if(!choice_convert_flag && now_steps === 1 && input_response.subtasks[0].choice_selection?.choices[8]?.id !== "ShownSensitiveDisturbingMediaOption"){
                         if(user_choice === 8){
                             //この条件が古くなっている可能性があるが、ページによって項目が変わってくる仕様のため、念の為残しておく

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Clean-Spam-Link-Tweet",
-  "version": "1.9.9.3",
+  "version": "1.9.9.4",
   "manifest_version": 3,
   "description": "ツイート(返信)から悪質なリンクが記載されたツイートを可視化してナイト系スパム等のリンクを踏む事を阻止します。",
   "icons" : {

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -1,6 +1,6 @@
 {
   "name": "Clean-Spam-Link-Tweet",
-  "version": "1.9.9.3",
+  "version": "1.9.9.4",
   "manifest_version": 2,
   "description": "ツイート(返信)から悪質なリンクが記載されたツイートを可視化してナイト系スパム等のリンクを踏む事を阻止します。",
   "icons" : {


### PR DESCRIPTION
## 追加されたもの
なし

## 直したもの
- 報告機能
  - 一部の環境で設定した報告モードで報告されない問題を修正

## 動作確認
- [x] Firefox系のブラウザでも問題なく動作するか
  - Floorp (FireFox: 149.0.3) で動作を確認

## その他の変更
なし

## マージ後の CSLT バージョン
- `1.9.9.4`


## 雑記(あればご自由にどうぞ)
今回の修正にあたり、調査への協力やフィードバックをいただいた方に大変感謝いたします。

不具合の内容として、限られた一部の環境で連続して報告をすることで、
X側からCSLT側へ想定外の規則でオプションが提示されていました。
そのため、CSLT側は規則の変化を判別できず、旧UI向けの仕組みで報告していたため、
設定とは異なるモードで報告がされていました。
今回の修正では、オプションの検出方法を変更し、想定外の規則にも追従できるようにしました！


#### 作業の時に聞いていた楽曲(覚えている限り)
- 星の声 - シャイニーカラーズ
  - https://youtu.be/XV6fnEG2gt4
- さくら、もゆ。～eufonius Ver.～ - eufonius
  - https://youtu.be/idMwfKlvVWI