### PR TITLE
feat: 新クライアント移行への事前準備

### DIFF
--- a/content.js
+++ b/content.js
@@ -223,6 +223,31 @@ document.head.insertAdjacentHTML("beforeend", `
 a[data-cslt-is-spam]{
     pointer-events: none;
 }
+
+/* 旧クライアント向けのCard警告 */
+[data-cslt-is-spam] > [data-testid="card.wrapper"] {
+    position: relative;
+}
+[data-cslt-is-spam] > [data-testid="card.wrapper"]::before {
+    content: "スパムを検出!\\Aヒットしたリンク: " var(--cslt-spam-host) "\\Aクリックでツイートを開く";
+    position: absolute;
+    inset: 0;
+    z-index: 99999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    background-color: rgba(0, 0, 0, 0.75);
+    color: #fff;
+    border-radius: 5px;
+    font-size: 0.8rem;
+    line-height: 1.3;
+}
+[data-cslt-is-spam]:has(> [data-testid="card.wrapper"]) {
+    pointer-events: none;
+}
 </style>
 `);
 
@@ -1577,6 +1602,9 @@ function main(filter_url, imp_filter_url) {
                                                 }
                                                 night_spam_twitter_card_elem.style.position = "relative";
                                                 ins_html = `<div class="cslt_spam_link_found" style="inset:0;border-radius:5px;"><p>スパムを検出!<br>ヒットしたURL:${cslt_tweet_info_obj.tw_card_obj.domain}<br>クリックでツイートを開く</p></div>`;
+                                            }else{
+                                                night_spam_twitter_card_elem.style.setProperty("--cslt-spam-host", JSON.stringify(cslt_tweet_info_obj.tw_card_obj.domain));
+                                                ins_html = "";
                                             }
                                             night_spam_twitter_card_elem.insertAdjacentHTML("afterbegin", ins_html);
                                             if (cslp_settings.hit_url_copy == true) {

--- a/content.js
+++ b/content.js
@@ -1896,12 +1896,12 @@ function main(filter_url, imp_filter_url) {
                                                                 case "0":
                                                                     if(tweet_info?.is_user_data_only != undefined){
                                                                         if(!tweet_info.is_user_data_only){
-                                                                            cslt_message_display("投稿の報告のみを行います", "message");
+                                                                            systemMessagePanel.setMessage("投稿の報告のみを行います", "info");
                                                                             report_tweet(cslp_settings.oneclick_report_option, target_element, tweet_info.tweet_id, location.host,"none", false, null).then((report_status) => {
                                                                                 resolve(report_status);
                                                                             });
                                                                         }else{
-                                                                            cslt_message_display("ユーザーの報告のみを行います", "message");
+                                                                            systemMessagePanel.setMessage("ユーザーの報告のみを行います", "info");
                                                                             report_tweet(cslp_settings.oneclick_report_option, target_element, tweet_info.user_data.user_id, location.host,"user", false, null).then((report_status) => {
                                                                                 resolve(report_status);
                                                                             });
@@ -1910,7 +1910,7 @@ function main(filter_url, imp_filter_url) {
                                                                     
                                                                     break;
                                                                 case "1":
-                                                                    cslt_message_display("ユーザーの報告のみを行います", "message");
+                                                                    systemMessagePanel.setMessage("ユーザーの報告のみを行います", "info");
                                                                     report_tweet(cslp_settings.oneclick_report_option, target_element, tweet_info.user_data.user_id, location.host,"user", false, null).then((report_status) => {
                                                                         resolve(report_status);
                                                                     });
@@ -1920,14 +1920,14 @@ function main(filter_url, imp_filter_url) {
                                                                         if(!tweet_info.is_user_data_only){
                                                                             //返信報告
                                                                             report_tweet(cslp_settings.oneclick_report_option, target_element, tweet_info.tweet_id, location.host,"none", false, null).then((report_status) => {
-                                                                                cslt_message_display("ユーザーの報告を行います", "message");
+                                                                                systemMessagePanel.setMessage("ユーザーの報告を行います", "info");
                                                                                 //ユーザー報告
                                                                                 report_tweet(cslp_settings.oneclick_report_option, target_element, tweet_info.user_data.user_id, location.host,"user", false, null).then((report_status) => {
                                                                                     resolve(report_status);
                                                                                 });
                                                                             });
                                                                         }else{
-                                                                            cslt_message_display("ユーザーの報告のみを行います", "message");
+                                                                            systemMessagePanel.setMessage("ユーザーの報告のみを行います", "info");
                                                                             report_tweet(cslp_settings.oneclick_report_option, target_element, tweet_info.user_data.user_id, location.host,"user", false, null).then((report_status) => {
                                                                                 resolve(report_status);
                                                                             });
@@ -1946,7 +1946,7 @@ function main(filter_url, imp_filter_url) {
                                                     }
                                                 } else {
                                                     //フォロー欄などのユーザーを報告した場合
-                                                    cslt_message_display("ユーザーの報告のみを行います", "message");
+                                                    systemMessagePanel.setMessage("ユーザーの報告のみを行います", "info");
                                                     report_tweet(cslp_settings.oneclick_report_option, target_element, tweet_info.user_data.user_id, location.host,"user", false, null).then((report_status) => {
                                                         resolve(report_status);
                                                     });
@@ -1963,13 +1963,13 @@ function main(filter_url, imp_filter_url) {
                                                 //
                                                 switch (cslp_settings.oneclick_report_target_mode) {
                                                     case "0":
-                                                        cslt_message_display("投稿の報告のみを行います", "message");
+                                                        systemMessagePanel.setMessage("投稿の報告のみを行います", "info");
                                                             report_tweet_community(cslp_settings.oneclick_report_option, target_element, tweet_info.tweet_id, location.host).then((report_status) => {
                                                                 resolve(report_status);
                                                             });
                                                         break;
                                                     case "1":
-                                                        cslt_message_display("ユーザーの報告のみを行います", "message");
+                                                        systemMessagePanel.setMessage("ユーザーの報告のみを行います", "info");
                                                         report_tweet(cslp_settings.oneclick_report_option, target_element, tweet_info.user_data.user_id, location.host,"user", false, null).then((report_status) => {
                                                             resolve(report_status);
                                                         });
@@ -1984,7 +1984,7 @@ function main(filter_url, imp_filter_url) {
                                                                     });
                                                                 });
                                                             }else{
-                                                                cslt_message_display("ユーザーの報告のみを行います", "message");
+                                                                systemMessagePanel.setMessage("ユーザーの報告のみを行います", "info");
                                                                 report_tweet(cslp_settings.oneclick_report_option, target_element, tweet_info.user_data.user_id, location.host,"user", false, null).then((report_status) => {
                                                                     resolve(report_status);
                                                                 });
@@ -2055,7 +2055,7 @@ function main(filter_url, imp_filter_url) {
                                             //開発者情報提供
                                             if (!tweet_info?.is_user_data_only && btn_mode != "notification" && is_follow_page() == false) {
                                                 developer_spam_user_share(report_srvurl, target_element);
-                                                cslt_message_display("情報提供の処理を行いました", "message");
+                                                systemMessagePanel.setMessage("情報提供の処理を行いました", "info");
                                             }
                                         }
                                         //this.classList.add("cslt_report_complete");
@@ -2067,7 +2067,7 @@ function main(filter_url, imp_filter_url) {
                                             //開発者情報提供
                                             if (!tweet_info?.is_user_data_only && btn_mode != "notification" && is_follow_page() == false) {
                                                 developer_spam_user_share(report_srvurl, target_element);
-                                                cslt_message_display("情報提供の処理を行いました", "message");
+                                                systemMessagePanel.setMessage("情報提供の処理を行いました", "info");
                                             }
                                         }
                                         //const tweet_info = JSON.parse(target_element.getAttribute("cslt_tweet_info"));
@@ -2089,7 +2089,7 @@ function main(filter_url, imp_filter_url) {
                                         //
                                     } else {
                                         document.querySelector('[id="layers"] div[role="group"] div div')?.click();
-                                        cslt_message_display("自身のツイートにこの操作はできません", "error");
+                                        systemMessagePanel.setMessage("自身のツイートにこの操作はできません", "error");
                                     }
                                 }
                                 if (cslp_settings.oneclick_report_after_mode == '4') {
@@ -2098,7 +2098,7 @@ function main(filter_url, imp_filter_url) {
                                             //開発者情報提供
                                             if (!tweet_info?.is_user_data_only && btn_mode != "notification" && is_follow_page() == false) {
                                                 developer_spam_user_share(report_srvurl, target_element);
-                                                cslt_message_display("情報提供の処理を行いました", "message");
+                                                systemMessagePanel.setMessage("情報提供の処理を行いました", "info");
                                             }
                                         }
                                         //const tweet_info = JSON.parse(target_element.getAttribute("cslt_tweet_info"));
@@ -2123,7 +2123,7 @@ function main(filter_url, imp_filter_url) {
                                         //
                                     } else {
                                         document.querySelector('[id="layers"] div[role="group"] div div')?.click();
-                                        cslt_message_display("自身のツイートにこの操作はできません", "error");
+                                        systemMessagePanel.setMessage("自身のツイートにこの操作はできません", "error");
                                     }
                                 }
                                 //開発者情報提供は通知とユーザーページでは無効とする
@@ -2136,12 +2136,12 @@ function main(filter_url, imp_filter_url) {
                                             if (is_follow_page() == false) {
                                                 developer_spam_user_share(report_srvurl, target_element);
                                                 tweet_area_clear(target_element, "report_only");
-                                                cslt_message_display("情報提供の処理を行いました", "message");
+                                                systemMessagePanel.setMessage("情報提供の処理を行いました", "info");
                                             }
                                             //this.classList.add("cslt_report_complete");
                                         } else {
                                             document.querySelector('[id="layers"] div[role="group"] div div')?.click();
-                                            cslt_message_display("自身のツイートにこの操作はできません", "error");
+                                            systemMessagePanel.setMessage("自身のツイートにこの操作はできません", "error");
                                         }
                                     }
                                 }
@@ -2158,10 +2158,10 @@ function main(filter_url, imp_filter_url) {
                                         //console.log(fail_report_tweet_status_ids_regex.test(tweet_info.tweet_id));
                                         switch (btn_mode) {
                                             case "notification":
-                                                cslt_message_display("通知のため、非表示処理はスキップされます", "message");
+                                                systemMessagePanel.setMessage("通知のため、非表示処理はスキップされます", "info");
                                                 break;
                                             case "user_page":
-                                                cslt_message_display("ブロック/ミュート処理は、再読み込みで反映を確認可能です", "message");
+                                                systemMessagePanel.setMessage("ブロック/ミュート処理は、再読み込みで反映を確認可能です", "info");
                                                 break;
                                             default:
                                                 if (cslp_settings.oneclick_report == true && cslp_settings.oneclick_report_after_mode == '0') {
@@ -2183,7 +2183,7 @@ function main(filter_url, imp_filter_url) {
                                 //this.classList.add("cslt_report_complete");
                             } else {
                                 document.querySelector('[id="layers"] div[role="group"] div div')?.click();
-                                cslt_message_display("自身のツイートにこの操作はできません", "error");
+                                systemMessagePanel.setMessage("自身のツイートにこの操作はできません", "error");
                             }
                         }
                     })
@@ -2499,7 +2499,7 @@ function main(filter_url, imp_filter_url) {
                     const copy_json = JSON.stringify(copy_obj);
                     navigator.clipboard.writeText(copy_json).then(() => {
                         //console.log(copy_json)
-                        cslt_message_display("クリップボードにJSONをコピーしました", "message");
+                        systemMessagePanel.setMessage("クリップボードにJSONをコピーしました", "info");
                     });
                 });
             }
@@ -2545,7 +2545,7 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
     //console.log(report_req_obj)
     //プロモーションの場合関数終了
     if (report_req_obj.is_promoted == true) {
-        cslt_message_display(`広告のため報告はスキップされます`, "warning");
+        systemMessagePanel.setMessage(`広告のため報告はスキップされます`, "warning");
         return true;
     }
     const get_ct0_token = await new Promise((resolve) => {
@@ -2620,7 +2620,7 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
                         if(input_response.subtasks[0].choice_selection.choices.some(option => option.id === simple_option_map[user_choice])){
                             report_type = simple_option_map[user_choice];
                         }else{
-                            cslt_message_display('設定された報告種別を選択できませんでした。スパムとして報告を行います', "message");
+                            systemMessagePanel.setMessage('設定された報告種別を選択できませんでした。スパムとして報告を行います', "info");
                         }
                         report_second_stage_body = `{\"flow_token\":\"${input_token_convert}\",\"subtask_inputs\":[{\"subtask_id\":\"single-selection\",\"choice_selection\":{\"link\":\"next_link\",\"selected_choices\":[\"${report_type}\"]}}]}`;
                     }else{
@@ -2661,37 +2661,37 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
                     if (response.status != 200) {
                         switch (response.status) {
                             case 429:
-                                cslt_message_display(`通報の${now_steps}ステップ目失敗(レートリミット)`, "error");
+                                systemMessagePanel.setMessage(`通報の${now_steps}ステップ目失敗(レートリミット)`, "error");
                                 console.error(response.status);
                                 resolve(false);
                                 //throw new Error(response.status);
                                 break;
                             case 304:
-                                cslt_message_display(`通報の${now_steps}ステップ目失敗(レートリミットの可能性)(Res:${response.status})`, "error");
+                                systemMessagePanel.setMessage(`通報の${now_steps}ステップ目失敗(レートリミットの可能性)(Res:${response.status})`, "error");
                                 console.error(response.status);
                                 resolve(false);
                                 //throw new Error(response.status);
                                 break;
                             default:
-                                cslt_message_display(`通報の${now_steps}ステップ目失敗(Res:${response.status})`, "error");
+                                systemMessagePanel.setMessage(`通報の${now_steps}ステップ目失敗(Res:${response.status})`, "error");
                                 console.error(response.status);
                                 resolve(false);
                                 //throw new Error(response.status);
                                 break;
                         }
                         /*if (response.status == 429) {
-                            cslt_message_display(`通報の${now_steps}ステップ目失敗(レートリミット)`, "error");
+                            systemMessagePanel.setMessage(`通報の${now_steps}ステップ目失敗(レートリミット)`, "error");
                             console.error(response.status);
                             resolve(false);
                             //throw new Error(response.status);
                         } else {
-                            cslt_message_display(`通報の${now_steps}ステップ目失敗(Res:${response.status})`, "error");
+                            systemMessagePanel.setMessage(`通報の${now_steps}ステップ目失敗(Res:${response.status})`, "error");
                             console.error(response.status);
                             resolve(false);
                             //throw new Error(response.status);
                         }*/
                     } else {
-                        cslt_message_display(`通報の${now_steps}ステップ目成功(Res:${response.status})`, "message");
+                        systemMessagePanel.setMessage(`通報の${now_steps}ステップ目成功(Res:${response.status})`, "info");
                         return response.json();
                     }
                 }).then((resp_json_secondstep) => {
@@ -2703,7 +2703,7 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
                             report_finalize = true;
                             send_srv(resp_json_secondstep);
                         } else {
-                            cslt_message_display(`通報の最終ステップ成功`, "message");
+                            systemMessagePanel.setMessage(`通報の最終ステップ成功`, "info");
                             if (fail_report_tweet_status_ids_regex != null && fail_report_tweet_status_ids_regex.test(report_twid) == true) {
                                 report_ids_temp(report_twid, "fail_report_delete");
                             }
@@ -2714,9 +2714,9 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
                     console.log("Report 2nd stage error");
                     //連続報告を行った際に発生するエラーを判定する
                     if(now_steps === 2 && error.message.includes("(reading 'subtasks')")){
-                        cslt_message_display(`通報の${now_steps}ステップ目失敗(連続報告により一時的に制限された可能性)`, "error");
+                        systemMessagePanel.setMessage(`通報の${now_steps}ステップ目失敗(連続報告により一時的に制限された可能性)`, "error");
                     }else{
-                        cslt_message_display(`通報の${now_steps}ステップ目失敗(${error.message})`, "error");
+                        systemMessagePanel.setMessage(`通報の${now_steps}ステップ目失敗(${error.message})`, "error");
                     }
                     report_ids_temp(report_twid, "fail_report");
                     console.log(error);
@@ -2742,14 +2742,14 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
         }).then(response => {
             if (response.status != 200) {
                 if (response.status == 429) {
-                    cslt_message_display(`通報の初期ステップ失敗(レートリミット)`, "error");
+                    systemMessagePanel.setMessage(`通報の初期ステップ失敗(レートリミット)`, "error");
                     throw new Error(response.status);
                 } else {
-                    cslt_message_display(`通報の初期ステップ失敗(Res:${response.status})`, "error");
+                    systemMessagePanel.setMessage(`通報の初期ステップ失敗(Res:${response.status})`, "error");
                     throw new Error(response.status);
                 }
             } else {
-                cslt_message_display(`通報の初期ステップ成功(Res:${response.status})`, "message");
+                systemMessagePanel.setMessage(`通報の初期ステップ成功(Res:${response.status})`, "info");
                 return response.json();
             }
         }).then((resp_json_firststep) => {
@@ -2760,7 +2760,7 @@ async function report_tweet(report_mode, report_element, report_twid, host_mode,
             });
         }).catch(error => {
             console.log("Report 1st stage error");
-            cslt_message_display(`通報の初期ステップ失敗(${error.message})`, "error");
+            systemMessagePanel.setMessage(`通報の初期ステップ失敗(${error.message})`, "error");
             report_ids_temp(report_twid, "fail_report");
             resolve(false);
             console.log(error);
@@ -2782,7 +2782,7 @@ function report_tweet_community(report_mode, report_element, report_twid, host_m
     let old_send_url = `https://${access_host}/i/report/status/${report_twid}`;
     //プロモーションの場合関数終了
     if (tweet_info_obj.is_promoted == true) {
-        cslt_message_display(`広告のため報告はスキップされます`, "warning");
+        systemMessagePanel.setMessage(`広告のため報告はスキップされます`, "warning");
         return true;
     }
     switch (report_mode_conv) {
@@ -2847,17 +2847,17 @@ function report_tweet_community(report_mode, report_element, report_twid, host_m
                 }).then(response => {
                     if (response.status != 200 && response.status != 302) {
                         if (response.status == 429) {
-                            cslt_message_display(`通報の${now_steps}ステップ目失敗(コミュニティ/レートリミット)`, "error");
+                            systemMessagePanel.setMessage(`通報の${now_steps}ステップ目失敗(コミュニティ/レートリミット)`, "error");
                             console.error(response.status);
                             resolve(false);
                         } else {
-                            cslt_message_display(`通報の${now_steps}ステップ目失敗(コミュニティ/Res:${response.status})`, "error");
+                            systemMessagePanel.setMessage(`通報の${now_steps}ステップ目失敗(コミュニティ/Res:${response.status})`, "error");
                             console.error(response.status);
                             resolve(false);
                         }
                     } else {
                         old_send_url = response.url;
-                        cslt_message_display(`通報の${now_steps}ステップ目成功(コミュニティ/Res:${response.status})`, "message");
+                        systemMessagePanel.setMessage(`通報の${now_steps}ステップ目成功(コミュニティ/Res:${response.status})`, "info");
                         return response.text();
                     }
                 }).then((resp_text_firststep) => {
@@ -2867,7 +2867,7 @@ function report_tweet_community(report_mode, report_element, report_twid, host_m
                         send_srv(resp_text_firststep);
                     } else {
                         //console.log("community report end!");
-                        cslt_message_display(`通報の最終ステップ成功(コミュニティ)`, "message");
+                        systemMessagePanel.setMessage(`通報の最終ステップ成功(コミュニティ)`, "info");
                         if (fail_report_tweet_status_ids_regex != null && fail_report_tweet_status_ids_regex.test(report_twid) == true) {
                             report_ids_temp(report_twid, "fail_report_delete");
                         }
@@ -2876,7 +2876,7 @@ function report_tweet_community(report_mode, report_element, report_twid, host_m
                 }).catch(error => {
                     console.log("Community Report 2nd stage error");
                     report_ids_temp(report_twid, "fail_report");
-                    cslt_message_display(`通報の${now_steps}ステップ目失敗(コミュニティ/${error.message})`, "error");
+                    systemMessagePanel.setMessage(`通報の${now_steps}ステップ目失敗(コミュニティ/${error.message})`, "error");
                     resolve(false);
                     console.log(error);
                 });
@@ -2899,15 +2899,15 @@ function report_tweet_community(report_mode, report_element, report_twid, host_m
             //console.log(response.ok)
             if (response.status != 200) {
                 if (response.status == 429) {
-                    cslt_message_display(`通報の初期ステップ失敗(コミュニティ/レートリミット)`, "error");
+                    systemMessagePanel.setMessage(`通報の初期ステップ失敗(コミュニティ/レートリミット)`, "error");
                     throw new Error(response.status);
                 } else {
-                    cslt_message_display(`通報の初期ステップ失敗(コミュニティ/Res:${response.status})`, "error");
+                    systemMessagePanel.setMessage(`通報の初期ステップ失敗(コミュニティ/Res:${response.status})`, "error");
                     throw new Error(response.status);
                 }
             } else {
                 old_send_url = response.url;
-                cslt_message_display(`通報の初期ステップ成功(コミュニティ/Res:${response.status})`, "message");
+                systemMessagePanel.setMessage(`通報の初期ステップ成功(コミュニティ/Res:${response.status})`, "info");
                 return response.text();
             }
         }).then((resp_text_firststep) => {
@@ -2918,7 +2918,7 @@ function report_tweet_community(report_mode, report_element, report_twid, host_m
             });
         }).catch(error => {
             console.log("Community Report 1st stage error");
-            cslt_message_display(`通報の初期ステップ失敗(コミュニティ/${error.message})`, "error");
+            systemMessagePanel.setMessage(`通報の初期ステップ失敗(コミュニティ/${error.message})`, "error");
             report_ids_temp(report_twid, "fail_report");
             resolve(false);
             console.log(error);
@@ -2951,11 +2951,11 @@ async function block_user(user_id, screen_name, host_mode) {
             }).then((resp) => {
                 if (resp.status != 200) {
                     if (resp.status == 429) {
-                        cslt_message_display("ブロックできません(レートリミット)", "error");
+                        systemMessagePanel.setMessage("ブロックできません(レートリミット)", "error");
                     }
                     throw new Error(resp.status);
                 } else {
-                    cslt_message_display("ブロックしました", "message");
+                    systemMessagePanel.setMessage("ブロックしました", "info");
                     if (fail_block_mute_user_ids_regex != null && fail_block_mute_user_ids_regex.test(user_id) == true) {
                         report_ids_temp(user_id, "fail_block_mute_delete");
                         //console.log(fail_block_mute_user_ids)
@@ -2969,7 +2969,7 @@ async function block_user(user_id, screen_name, host_mode) {
                 console.log("fail block");
                 console.log(error);
                 report_ids_temp(user_id, "fail_block_mute");
-                cslt_message_display(`ブロックできません(${error.message})`, "error");
+                systemMessagePanel.setMessage(`ブロックできません(${error.message})`, "error");
                 resolve(false);
             });
         });
@@ -3005,11 +3005,11 @@ async function mute_user(user_id, screen_name, host_mode) {
             }).then((resp) => {
                 if (resp.status != 200) {
                     if (resp.status == 429) {
-                        cslt_message_display("ミュートできません(レートリミット)", "error");
+                        systemMessagePanel.setMessage("ミュートできません(レートリミット)", "error");
                     }
                     throw new Error(resp.status);
                 } else {
-                    cslt_message_display("ミュートしました", "message");
+                    systemMessagePanel.setMessage("ミュートしました", "info");
                     if (fail_block_mute_user_ids_regex != null && fail_block_mute_user_ids_regex.test(user_id) == true) {
                         report_ids_temp(user_id, "fail_block_mute_delete");
                     }
@@ -3022,7 +3022,7 @@ async function mute_user(user_id, screen_name, host_mode) {
                 console.log("fail mute");
                 console.log(error);
                 report_ids_temp(user_id, "fail_block_mute");
-                cslt_message_display(`ミュートできません(${error.message})`, "error");
+                systemMessagePanel.setMessage(`ミュートできません(${error.message})`, "error");
                 resolve(false);
             });
         });
@@ -3101,7 +3101,7 @@ async function get_block_mute_list(mode, host_mode, cursor_id) {
 
                 if (lists_api_access.status != 200) {
                     if (lists_api_access.status == 429) {
-                        cslt_message_display("リストが取得できません(レートリミット)", "error");
+                        systemMessagePanel.setMessage("リストが取得できません(レートリミット)", "error");
                         if (cursor_str == null) {
                             //console.log(lists_api_access)
                             const limit_date = new Date(lists_api_access.headers.get("x-rate-limit-reset") * 1000);
@@ -3132,7 +3132,7 @@ async function get_block_mute_list(mode, host_mode, cursor_id) {
                     resolve(user_lists_concat);
                 }
             } catch (error) {
-                cslt_message_display(`リストが取得できません(${error.message})`, "error");
+                systemMessagePanel.setMessage(`リストが取得できません(${error.message})`, "error");
                 console.error(error)
                 if (user_lists_concat.length == 0) {
                     resolve(null);
@@ -3189,7 +3189,7 @@ function cslt_message_display_init() {
     Object.assign(content.style, {
         display: "flex",
         height: "100%",
-        padding: "10px",
+        padding: "0 10px",
         color: "white",
         borderRadius: "5px",
         textAlign: "center",
@@ -3208,7 +3208,7 @@ function cslt_message_display_init() {
 
     return {
         //メッセージ設定の関数を返す
-        setMessage(message, mode = "info", autoCloseMs = 3000){
+        setMessage(message, mode = "info", autoCloseMs = 5000){
             if (!document.contains(wrap)) document.body.prepend(wrap);
 
             text.textContent = message;
@@ -3222,28 +3222,6 @@ function cslt_message_display_init() {
     };
 }
 
-//ユーザーメッセージ表示関数
-async function cslt_message_display(message, mode) {
-    new Promise(() => {
-        document.querySelector(".cslt_message_wrap").style.display = "flex";
-        document.querySelector(".cslt_message_span").textContent = message;
-        switch (mode) {
-            case "warning":
-                document.querySelector(".cslt_message_content").style.backgroundColor = "#f0721d";
-                break;
-            case "error":
-                document.querySelector(".cslt_message_content").style.backgroundColor = "#f01d47";
-                break;
-
-            default:
-                document.querySelector(".cslt_message_content").style.backgroundColor = "#1d9bf0";
-                break;
-        }
-        setTimeout(function () {
-            document.querySelector(".cslt_message_wrap").style.display = "none";
-        }, 5000);
-    });
-}
 async function tweet_area_clear(target_element, mode) {
     new Promise(() => {
         const target_tweet_info = JSON.parse(target_element.getAttribute("cslt_tweet_info"));
@@ -3338,7 +3316,7 @@ function block_mute_io() {
                 } else {
                     user_list = await get_block_mute_list("block", location.host, null);
                 }
-                cslt_message_display("ユーザーリストの取得中", "message");
+                systemMessagePanel.setMessage("ユーザーリストの取得中", "info");
                 user_list.forEach((user_data) => {
                     if (user_data.content.itemContent?.user_results != undefined) {
                         //console.log(user_data.content.itemContent.user_results.result.legacy.name)
@@ -3358,13 +3336,13 @@ function block_mute_io() {
                 } else {
                     user_list = await get_block_mute_list("mute", location.host, null);
                 }
-                cslt_message_display("ユーザーリストの取得中", "message");
+                systemMessagePanel.setMessage("ユーザーリストの取得中", "info");
                 user_list.forEach((user_data) => {
                     if (user_data.content.itemContent?.user_results != undefined) {
                         export_user_list.push(user_data.content.itemContent.user_results.result);
                     }
                 });
-                cslt_message_display("ユーザーリストのダウンロードを行います", "message");
+                systemMessagePanel.setMessage("ユーザーリストのダウンロードを行います", "info");
                 download_list(export_user_list, "Mute");
             }
         })
@@ -3392,9 +3370,9 @@ function block_mute_io() {
                     if (confirm(`${input_user_list.length}件のユーザーを現在のリストに追加しますか？`)) {
                         if (window.location.pathname.split("/")[2] == 'blocked') {
                             let now_status_num = 1;
-                            cslt_message_display("処理を開始します", "message");
+                            systemMessagePanel.setMessage("処理を開始します", "info");
                             for (const user_data of input_user_list) {
-                                cslt_message_display(`${now_status_num}/${input_user_list.length}処理中-${user_data.legacy.name}`, "message");
+                                systemMessagePanel.setMessage(`${now_status_num}/${input_user_list.length}処理中-${user_data.legacy.name}`, "info");
                                 //console.log(user_data.rest_id)
                                 //console.log(user_data.legacy.name)
                                 const block_run = await new Promise((resolve) => {
@@ -3415,14 +3393,14 @@ function block_mute_io() {
                                     break;
                                 }
                                 if (now_status_num > input_user_list.length) {
-                                    cslt_message_display("処理が完了しました", "message");
+                                    systemMessagePanel.setMessage("処理が完了しました", "info");
                                 }
                             }
                         } else {
                             let now_status_num = 1;
-                            cslt_message_display("処理を開始します", "message");
+                            systemMessagePanel.setMessage("処理を開始します", "info");
                             for (const user_data of input_user_list) {
-                                cslt_message_display(`${now_status_num}/${input_user_list.length}処理中-${user_data.legacy.name}`, "message");
+                                systemMessagePanel.setMessage(`${now_status_num}/${input_user_list.length}処理中-${user_data.legacy.name}`, "info");
                                 //console.log(user_data.rest_id)
                                 //console.log(user_data.legacy.name)
                                 const mute_run = await new Promise((resolve) => {
@@ -3443,14 +3421,14 @@ function block_mute_io() {
                                     break;
                                 }
                                 if (now_status_num > input_user_list.length) {
-                                    cslt_message_display("処理が完了しました！リストを開き直してください", "message");
+                                    systemMessagePanel.setMessage("処理が完了しました！リストを開き直してください", "info");
                                 }
                             }
                         }
                     }
                 }
                 file_reader.onerror = function () {
-                    cslt_message_display("ファイルの読み込みに失敗しました", "error");
+                    systemMessagePanel.setMessage("ファイルの読み込みに失敗しました", "error");
                 }
             }
             this.value = '';

--- a/content.js
+++ b/content.js
@@ -45,6 +45,9 @@ let fail_report_tweet_status_ids_regex = /a^/;
 //ブロック・ミュート失敗ID格納
 let fail_block_mute_user_ids = [];
 let fail_block_mute_user_ids_regex = /a^/;
+//新クライアント検出フラグ
+let is_new_client = false;
+
 //報告情報一時保管関数
 function report_ids_temp(id, mode) {
     if (id == null || id == undefined) {
@@ -244,6 +247,7 @@ document.head.appendChild(tweet_info_script);
 
 //メッセージパネル挿入
 document.body.insertAdjacentHTML("afterbegin", '<div class="cslt_message_wrap"><div class="cslt_message_content"><span class="cslt_message_span">CSLTメッセージ</span></div></div>');
+const systemMessagePanel = cslt_message_display_init();
 //
 chrome.storage.local.get("cslp_settings", function (value) {
     if (value.cslp_settings != undefined) {
@@ -466,7 +470,14 @@ function main(filter_url, imp_filter_url) {
             } else {
                 console.log("CSLT Settings Found!");
                 cslp_settings = JSON.parse(cslp_settings.cslp_settings);
-                const target_elem = document.getElementById("react-root");
+                //クライアントのルートを取得する
+                let target_elem = document.getElementById("react-root");
+                if(!target_elem){
+                    //新クライアントの場合
+                    target_elem = document.querySelector('main');
+                    is_new_client = true;
+                }
+                console.log(target_elem)
                 //Write Latest Version
                 cslp_settings.filter_update = json[0].developer_update;
                 cslp_settings.filter_link = json[0].thanks_link;
@@ -736,8 +747,10 @@ function main(filter_url, imp_filter_url) {
                     const tweet_root_user_scrname = get_tweet_status_root_user();
                     const target_tweet_ids = [];
                     //ターゲット要素取得(任意のフラグは「:not()」内にOR条件で追加しましょう)
-                    const target_selector = `div[data-testid="cellInnerDiv"][cslt_tweet_info]:not([cslt_tweet_info_mytweet_flag="true"],[cslt_white_list_user],[cslt_hide_flag="true"],[cslt_blue_bypass_flag="true"],[cslt_night_spam_processed_flag="true"],[cslt_process_ok="true"],[cslt_temp_fail_report_flag="fail_tweet"])`;//,[cslt_report_btn_set_flag="true"] ${cslt_exclusion_css_flag}
+                    const not_selector = `:not([cslt_tweet_info_mytweet_flag="true"],[cslt_white_list_user],[cslt_hide_flag="true"],[cslt_blue_bypass_flag="true"],[cslt_night_spam_processed_flag="true"],[cslt_process_ok="true"],[cslt_temp_fail_report_flag="fail_tweet"])`;
+                    const target_selector = `div[data-testid="cellInnerDiv"][cslt_tweet_info]${not_selector},li[cslt_tweet_info]${not_selector}`;//,[cslt_report_btn_set_flag="true"] ${cslt_exclusion_css_flag}
                     const target_tweet_element = target_elem.querySelectorAll(target_selector);
+                    console.log(target_tweet_element)
                     /* 非表示等動作 */
                     /* TIPS:新しい非表示機能付けたけど画面が固まってしまう場合、フラグが立っていない可能性があります！
                     非表示処理後は「cslt_hide_flag」の値を「true」にしたフラグを立てましょう。
@@ -1741,24 +1754,42 @@ function main(filter_url, imp_filter_url) {
                         }
                         input_element.querySelector('[data-testid="UserCell"]')?.insertAdjacentHTML("beforeend", `<a cslt_report_btn id="${random_id}" class="cslt_report_icon" title="報告"></a>`);
                     } else {
+                        const is_input_elem_li = input_element.tagName === 'LI';
                         //"follow"
                         switch (btn_mode) {
                             case "follow":
-                                input_element.querySelector('[data-testid="UserCell"]').insertAdjacentHTML("beforeend", `<a cslt_report_btn id="${random_id}" class="cslt_report_icon" title="報告"></a>`);
+                                //新クライアントは現状、調査ができないので一旦無効にしておく
+                                if (!is_new_client){
+                                    input_element.querySelector('[data-testid="UserCell"]').insertAdjacentHTML("beforeend", `<a cslt_report_btn id="${random_id}" class="cslt_report_icon" title="報告"></a>`);
+                                }
                                 break;
                             case "share":
                                 //従来のボタン配置
-                                input_element.querySelector('div[role="group"]:not([cslt_flag="report_ok"])').insertAdjacentHTML("beforeend", `<a cslt_report_btn id="${random_id}" class="cslt_report_icon" title="報告"></a>`);
+                                if(is_input_elem_li){
+                                    input_element.querySelector('button[id^="base-ui-"]:not([cslt_flag="report_ok"])').insertAdjacentHTML("afterend", `<a cslt_report_btn id="${random_id}" class="cslt_report_icon" title="報告"></a>`);
+                                }else{
+                                    input_element.querySelector('div[role="group"]:not([cslt_flag="report_ok"])').insertAdjacentHTML("beforeend", `<a cslt_report_btn id="${random_id}" class="cslt_report_icon" title="報告"></a>`);
+                                }
                                 break;
                             case "more":
                                 //もっと見る付近に配置
-                                input_element.querySelector('article').insertAdjacentHTML("beforeend", `<div class="cslt_report_icon_tweetmore_wrap"><a cslt_report_btn id="${random_id}" class="cslt_report_icon" title="報告"></a></div>`);
+                                if(is_input_elem_li){
+                                    input_element.querySelector('button[aria-haspopup="dialog"]:has(svg[data-icon="icon-more"])').insertAdjacentHTML("afterend", `<a cslt_report_btn id="${random_id}" class="cslt_report_icon" title="報告"></a>`);
+                                }else{
+                                    input_element.querySelector('article').insertAdjacentHTML("beforeend", `<div class="cslt_report_icon_tweetmore_wrap"><a cslt_report_btn id="${random_id}" class="cslt_report_icon" title="報告"></a></div>`);
+                                }
                                 break;
                             case "notification":
-                                input_element.querySelector('.cslt_report_icon_notification_wrap').insertAdjacentHTML("beforeend", `<a cslt_report_btn id="${random_id}" class="cslt_report_icon" title="${notification_user_page_data.user_data.name}(@${notification_user_page_data.user_data.scr_name})を報告"></a>`);
+                                //新クライアントは現状、調査ができないので一旦無効にしておく
+                                if (!is_new_client){
+                                    input_element.querySelector('.cslt_report_icon_notification_wrap').insertAdjacentHTML("beforeend", `<a cslt_report_btn id="${random_id}" class="cslt_report_icon" title="${notification_user_page_data.user_data.name}(@${notification_user_page_data.user_data.scr_name})を報告"></a>`);
+                                }
                                 break;
                             case "user_page":
-                                input_element.closest('div[aria-label][tabindex="0"]').querySelector('button[data-testid="userActions"][aria-haspopup="menu"][role="button"]').insertAdjacentHTML("afterend", `<a cslt_report_btn id="${random_id}" class="cslt_report_user_page" title="このユーザーを報告"><div class="cslt_report_icon"></div></a>`);
+                                //新クライアントは現状、調査ができないので一旦無効にしておく
+                                if (!is_new_client){
+                                    input_element.closest('div[aria-label][tabindex="0"]').querySelector('button[data-testid="userActions"][aria-haspopup="menu"][role="button"]').insertAdjacentHTML("afterend", `<a cslt_report_btn id="${random_id}" class="cslt_report_user_page" title="このユーザーを報告"><div class="cslt_report_icon"></div></a>`);
+                                }
                                 break;
                             default:
 
@@ -1779,6 +1810,13 @@ function main(filter_url, imp_filter_url) {
                     }
                     //報告ボタン動作
                     document.getElementById(random_id)?.addEventListener("click", async function () {
+                        //非ログイン状態では報告機能諸々は利用できないので早期にreturnしておく
+                        const ct0 = await ct0_token_get(location.host)
+                        if (!ct0){
+                            systemMessagePanel.setMessage(`ログインされていないため報告ボタンは機能しません`, "error");
+                            return;
+                        };
+
                         let get_cookie_twid = null;
                         //ログインユーザーID取得
                         if (is_use_cookie_mode()) {
@@ -1802,7 +1840,7 @@ function main(filter_url, imp_filter_url) {
                         if (report_confirm == true) {
                             const report_srvurl = cslp_settings.oneclick_developer_reportsrv_url;
                             //console.log(random_id);
-                            const target_element = this.closest('[data-testid="cellInnerDiv"]');
+                            const target_element = this.closest('[data-testid="cellInnerDiv"], li[cslt_tweet_info]');
                             //console.log(target_element)
                             let tweet_info = null;
                             switch (btn_mode) {
@@ -3126,6 +3164,64 @@ function developer_spam_user_share(report_srv, spam_element) {
     //console.log({tweet_user_id:tweet_user_id, tweet_user_name:tweet_uesr_name, tweet_text:tweet_text, tweet_length:tweet_text_length})
     chrome.runtime.sendMessage({ message: { mode: "developer_report_share", target: { report_srv_url: report_srv, tweet_user_id: tweet_user_id, tweet_user_name: tweet_uesr_name, tweet_text: tweet_text, tweet_length: tweet_text_length, report_json_data: report_json_del_privacy } } }, (response) => { });
 }
+//ユーザーメッセージ表示領域初期化関数
+function cslt_message_display_init() {
+    //カラーを定義
+    const colors = {
+        info:    "#1d9bf0",
+        warning: "#f0721d",
+        error:   "#f01d47",
+    };
+    //メッセージラッパーを設定
+    const wrap = document.createElement("div");
+    Object.assign(wrap.style, {
+        display: "none",
+        position: "fixed",
+        bottom: "4rem",
+        width: "100vw",
+        height: "2rem",
+        zIndex: "9999",
+        alignItems: "center",
+        justifyContent: "center",
+    });
+    //メッセージ本体を設定
+    const content = document.createElement("div");
+    Object.assign(content.style, {
+        display: "flex",
+        height: "100%",
+        padding: "10px",
+        color: "white",
+        borderRadius: "5px",
+        textAlign: "center",
+        alignContent: "center",
+        justifyContent: "center",
+        alignItems: "center",
+        fontFamily: "system-ui",
+    });
+
+    const text = document.createElement("span");
+    content.append(text);
+    wrap.append(content);
+    document.body.prepend(wrap);
+
+    let timer = null;
+
+    return {
+        //メッセージ設定の関数を返す
+        setMessage(message, mode = "info", autoCloseMs = 3000){
+            if (!document.contains(wrap)) document.body.prepend(wrap);
+
+            text.textContent = message;
+            content.style.backgroundColor = colors[mode] || colors.info;
+            wrap.style.display = "flex";
+            if (timer) clearTimeout(timer);
+            if (autoCloseMs > 0) {
+                timer = setTimeout(() => { wrap.style.display = "none"; }, autoCloseMs);
+            }
+        },
+    };
+}
+
 //ユーザーメッセージ表示関数
 async function cslt_message_display(message, mode) {
     new Promise(() => {
@@ -3178,12 +3274,12 @@ function ctid_create() {
     return btoa(String.fromCharCode.apply(null, crypto.getRandomValues(new Uint8Array(70)))).replaceAll("=", "");
 }
 async function ct0_token_get(host_mode) {
-    return await new Promise(async (resolve) => {
+    return await new Promise(async (resolve, reject) => {
         const is_private_mode = chrome.extension.inIncognitoContext;
         //console.log(is_use_cookie_mode())
         if (is_private_mode || is_use_cookie_mode()) {
-            const doc_cookie_ct0 = document.cookie.match(/(?:^|;\s*)ct0=([^;]*)/)[1];
-            resolve(doc_cookie_ct0);
+            const doc_cookie_ct0 = document.cookie.match(/(?:^|;\s*)ct0=([^;]*)/)?.[1];
+            resolve(doc_cookie_ct0 || false);
         } else {
             const get_broswer_api_ct0 = await new Promise((api_resolve) => {
                 chrome.runtime.sendMessage({ message: { mode: "ct0_token_get", target: { target_host_mode: host_mode } } }, (response) => {
@@ -3195,8 +3291,8 @@ async function ct0_token_get(host_mode) {
                 resolve(get_broswer_api_ct0);
             } else {
                 //console.log("DocumentMode")
-                const doc_cookie_ct0 = document.cookie.match(/(?:^|;\s*)ct0=([^;]*)/)[1];
-                resolve(doc_cookie_ct0);
+                const doc_cookie_ct0 = document.cookie.match(/(?:^|;\s*)ct0=([^;]*)/)?.[1];
+                resolve(doc_cookie_ct0 || false);
             }
         }
     })

--- a/content.js
+++ b/content.js
@@ -2257,7 +2257,7 @@ function main(filter_url, imp_filter_url) {
                     document.getElementById(copy_btn_random_id).addEventListener("click", function () {
                         //console.log(this)
                         //ツイート情報取得
-                        const get_tw_id_url = new URL(this.closest('[data-testid="cellInnerDiv"]').querySelector('[data-testid="User-Name"]  a[dir="ltr"], div[dir="ltr"] [aria-describedby][role="link"]').href);
+                        const get_tw_id_url = new URL(this.closest('[data-testid="cellInnerDiv"]').querySelector('[data-testid="User-Name"]  a[dir="ltr"], div[dir="ltr"] [aria-describedby][role="link"], div[id][aria-labelledby] a').href);
                         const get_tw_date = new Date(this.closest('[data-testid="cellInnerDiv"]').querySelector('[data-testid="User-Name"] a[dir="ltr"] time, div[dir="ltr"] [aria-describedby][role="link"] time').getAttribute("datetime"));
                         copy_tw_id = get_tw_id_url.pathname.match("/status/(\\d+)")[1];
                         copy_tw_date = `${get_tw_date.getFullYear()}_${(get_tw_date.getMonth() + 1).toString().padStart(2, '0')}_${get_tw_date.getDate().toString().padStart(2, '0')}_${get_tw_date.getHours()}_${get_tw_date.getMinutes()}_${get_tw_date.getSeconds()}`;

--- a/content.js
+++ b/content.js
@@ -2548,6 +2548,7 @@ function main(filter_url, imp_filter_url) {
             function copy_tweet_data(element_json, target_id) {
                 document.getElementById(target_id).addEventListener("click", function () {
                     const copy_obj = JSON.parse(element_json);
+                    delete copy_obj.user_report_json;
                     delete copy_obj.report_json;
                     const copy_json = JSON.stringify(copy_obj);
                     navigator.clipboard.writeText(copy_json).then(() => {
@@ -3203,16 +3204,17 @@ async function get_block_mute_list(mode, host_mode, cursor_id) {
 //開発者提供用関数
 function developer_spam_user_share(report_srv, spam_element) {
     const report_json_del_privacy = JSON.parse(spam_element.getAttribute('cslt_tweet_info'));
-    //提供者情報を含むデータを削除
+    //不要なデータを削除
+    delete report_json_del_privacy.user_report_json;
     delete report_json_del_privacy.report_json;
     //console.log(report_json_del_privacy)
     let tweet_user_id = null;
     let tweet_uesr_name = null;
     let tweet_text = null;
     let tweet_text_length = null;
-    tweet_user_id = spam_element.querySelector('[data-testid="User-Name"]  a').href.replace(/(https:\/\/x.com\/|https:\/\/twitter.com\/)/g, "");
-    tweet_uesr_name = spam_element.querySelector('article [data-testid="User-Name"] a').textContent;
-    tweet_text = `${spam_element.querySelector('article[data-testid="tweet"] [aria-labelledby]')?.innerText}%and%${spam_element.querySelector('[aria-labelledby] div[data-testid="tweetText"]')?.innerText}`;
+    tweet_user_id = report_json_del_privacy.user_data.scr_name;
+    tweet_uesr_name = report_json_del_privacy.user_data.name
+    tweet_text = report_json_del_privacy.text;
     tweet_text_length = tweet_text.length;
     //console.log({tweet_user_id:tweet_user_id, tweet_user_name:tweet_uesr_name, tweet_text:tweet_text, tweet_length:tweet_text_length})
     chrome.runtime.sendMessage({ message: { mode: "developer_report_share", target: { report_srv_url: report_srv, tweet_user_id: tweet_user_id, tweet_user_name: tweet_uesr_name, tweet_text: tweet_text, tweet_length: tweet_text_length, report_json_data: report_json_del_privacy } } }, (response) => { });

--- a/content.js
+++ b/content.js
@@ -512,10 +512,10 @@ function main(filter_url, imp_filter_url) {
                     scam_induction_spam_user_text_regexp = new RegExp(json[1].scam_induction_spam_user_text);
                 }
                 if (cslp_settings.user_register_hideuser.length != 0) {
-                    hide_user_list_regexp = array_regexp_escape(cslp_settings.user_register_hideuser, false);
+                    hide_user_list_regexp = array_regexp_escape(cslp_settings.user_register_hideuser, false, true);
                 }
                 if (cslp_settings.user_register_whitelist.length != 0) {
-                    user_whitelist_regexp = array_regexp_escape(cslp_settings.user_register_whitelist, false);
+                    user_whitelist_regexp = array_regexp_escape(cslp_settings.user_register_whitelist, false, true);
                 }
                 //投稿自動化ツールクライアント正規表現作成
                 if(cslp_settings.auto_tweet_tools_tweet_block){
@@ -3446,12 +3446,12 @@ function block_mute_io() {
     }
 }
 //配列内文字列エスケープ処理&正規表現作成関数
-function array_regexp_escape(input_array, is_group){
-    if(is_group){
-        return new RegExp(`(${input_array.join("<-NO_RP->").replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/<-NO_RP->/g, "|")})`, 'g');
-    }else{
-        return new RegExp(`(${input_array.join("<-NO_RP->").replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/<-NO_RP->/g, "|")})`);
-    }
+function array_regexp_escape(input_array, is_group, anchor=false){
+    let pattern = `(${input_array.map(s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join("|")})`;
+
+    if(anchor) pattern = `^${pattern}$`;
+
+    return new RegExp(pattern, is_group ? "g" : "");
 }
 //任意月以内検出関数
 function is_date_with_month(date, range){

--- a/content.js
+++ b/content.js
@@ -711,15 +711,6 @@ function main(filter_url, imp_filter_url) {
                         return false;
                     }
                 }
-                //要素検証用関数
-                function target_element_num(input_element_num, input_selector){
-                    const target_verifi_element = target_elem.querySelectorAll(input_selector);
-                    if(input_element_num == target_verifi_element.length){
-                        return true;
-                    }else{
-                        return false;
-                    }
-                }
                 /* メイン動作関数 */
                 function run() {
                     //const cslt_performance_logging_start = performance.now();
@@ -744,11 +735,12 @@ function main(filter_url, imp_filter_url) {
                     非表示処理後は「cslt_hide_flag」の値を「true」にしたフラグを立てましょう。
                     非表示以外の機能追加の場合は分かりやすい任意のフラグを追加してください！*/
                     for (let target_index = 0; target_index < target_tweet_element.length; target_index++) {
-                        //要素取りこぼし検証
-                        if (!target_element_num(target_tweet_element.length, target_selector)) {
-                            break;
-                        }
                         const cslt_target_tweet_elem = target_tweet_element[target_index];
+                        //要素がまだDOM上に残っているかチェックする
+                        if (!cslt_target_tweet_elem.isConnected) continue;
+                        //処理の対象であるかどうかチェックする
+                        if (!cslt_target_tweet_elem.matches(target_selector)) continue;
+                        
                         const cslt_tweet_info_obj = JSON.parse(cslt_target_tweet_elem.getAttribute('cslt_tweet_info'));
                         //フォロー中ユーザー除外設定フラグ
                         let processing_following_user_exclusion_flag = true;

--- a/content.js
+++ b/content.js
@@ -1637,6 +1637,9 @@ function main(filter_url, imp_filter_url) {
                                                 }
                                                 night_spam_twitter_card_elem.style.position = "relative";
                                                 ins_html = `<div class="cslt_spam_link_found" style="inset:0;border-radius:5px;"><p>スパムを検出!<br>ヒットしたURL:${video_card_url.host}<br>クリックでツイートを開く</p></div>`;
+                                            }else{
+                                                night_spam_twitter_card_elem.style.setProperty("--cslt-spam-host", `"${video_card_url.host}"`);
+                                                ins_html = "";
                                             }
                                             night_spam_twitter_card_elem.insertAdjacentHTML("afterbegin", ins_html);
                                             if (cslp_settings.hit_url_copy == true) {

--- a/content.js
+++ b/content.js
@@ -248,6 +248,11 @@ a[data-cslt-is-spam]{
 [data-cslt-is-spam]:has(> [data-testid="card.wrapper"]) {
     pointer-events: none;
 }
+
+/* 新クライアント向けの投稿情報コピーパネル */
+li[cslt_tweet_info]:has(.cslt_tweetdata_copy) {
+  position: relative;
+}
 </style>
 `);
 
@@ -1844,10 +1849,14 @@ function main(filter_url, imp_filter_url) {
                     if (cslp_settings.hit_url_copy == true && btn_mode != "notification") {
                         //URLコピー用要素追加
                         let tweet_info_copy_ins_html = `<div id="cslt_tweet_info_copy_${random_id}" class="cslt_tweetdata_copy" style="width: 100%;height: 100%;position: absolute;z-index: 100;display: flex;align-items: center;text-align: center;justify-content: center;font-weight:bold;background-color: rgba(0,0,0,0.75);color: #fff;outline:solid 5px #1173ff;outline-offset:-5px;cursor:copy;visibility:hidden;">クリックで情報をコピー</div>`;
-                        const reply_elem_user_cell_copy = input_element.closest('[data-testid="cellInnerDiv"], [data-testid="UserCell"]:not([cslt_copy_tweet_data_success])');
-                        reply_elem_user_cell_copy.insertAdjacentHTML("afterbegin", tweet_info_copy_ins_html);
-                        copy_tweet_data(reply_elem_user_cell_copy.getAttribute("cslt_tweet_info"), `cslt_tweet_info_copy_${random_id}`);
-                        reply_elem_user_cell_copy.setAttribute('cslt_copy_tweet_data_success', '');
+                        const reply_elem_user_cell_copy = input_element.closest('li[cslt_tweet_info], [data-testid="cellInnerDiv"], [data-testid="UserCell"]:not([cslt_copy_tweet_data_success])');
+                        
+                        //ターゲットとなる投稿本体の存在状態によって追加を決定する
+                        if(reply_elem_user_cell_copy){
+                            reply_elem_user_cell_copy.insertAdjacentHTML("afterbegin", tweet_info_copy_ins_html);
+                            copy_tweet_data(reply_elem_user_cell_copy.getAttribute("cslt_tweet_info"), `cslt_tweet_info_copy_${random_id}`);
+                            reply_elem_user_cell_copy.setAttribute('cslt_copy_tweet_data_success', '');
+                        }
                     }
                     //報告ボタン動作
                     document.getElementById(random_id)?.addEventListener("click", async function () {
@@ -2231,6 +2240,9 @@ function main(filter_url, imp_filter_url) {
                 }
                 //URLコピー関数(ナイト系スパム関連。レガシー)
                 function copy_url(input_element) {
+                    //レガシー機能のため、新クライアントでは無効にする
+                    if(is_new_client) return;
+
                     //コピー変数
                     let copy_tw_id = null;
                     let copy_tw_date = null;

--- a/content.js
+++ b/content.js
@@ -2436,7 +2436,7 @@ function main(filter_url, imp_filter_url) {
                             }
                             //アドバンスド解析ベースモードからのt.coリンク取得部分移植
                             function get_tco_new(input_element) {
-                                let target_element_a = input_element.parentElement.querySelectorAll('[data-testid="card.wrapper"] a , [data-testid="tweetText"] a');
+                                let target_element_a = input_element.parentElement.querySelectorAll('[data-testid="card.wrapper"] a,  div[aria-labelledby] a, [data-testid="tweetText"] a');
                                 let target_url = null;
                                 if (input_element.parentElement.querySelectorAll('[data-testid="tweetText"] a').length != 0) {
                                     target_element_a = input_element.parentElement.querySelectorAll('[data-testid="tweetText"] a');

--- a/content.js
+++ b/content.js
@@ -231,9 +231,17 @@ document.head.insertAdjacentHTML("beforeend", `
 }
 </style>
 `);
+
+//新クライアント向け情報抽出スクリプト
+const new_tweet_info_script = document.createElement('script');
+new_tweet_info_script.src = chrome.runtime.getURL("cslt_tweet_ctrl_relay.js");
+document.head.appendChild(new_tweet_info_script);
+
+//従来の情報抽出スクリプト
 const tweet_info_script = document.createElement('script');
 tweet_info_script.src = chrome.runtime.getURL("cslt_tweet_ctrl.js");
 document.head.appendChild(tweet_info_script);
+
 //メッセージパネル挿入
 document.body.insertAdjacentHTML("afterbegin", '<div class="cslt_message_wrap"><div class="cslt_message_content"><span class="cslt_message_span">CSLTメッセージ</span></div></div>');
 //

--- a/content.js
+++ b/content.js
@@ -831,7 +831,7 @@ function main(filter_url, imp_filter_url) {
                                 //ユーザー非表示ワードリスト
                                 if (cslp_settings.user_register_word_list != "") {
                                     //ユーザープロフィール文チェック
-                                    if (cslp_settings.user_register_word_hide_profile) {
+                                    if (cslp_settings.user_register_word_hide_profile && typeof cslt_tweet_info_obj.user_data.description === "string") {
                                         if (user_blocking_word_list_regexp.test(cslt_tweet_info_obj.user_data.description)) {
                                             //console.log("UserWordListProfile=>"+cslt_tweet_info_obj.text)
                                             cslt_target_tweet_elem.setAttribute("cslt_hide_flag", "true");
@@ -1043,7 +1043,7 @@ function main(filter_url, imp_filter_url) {
                                         continue;
                                     }
                                     //ユーザープロフィール文チェック
-                                    if(scam_induction_spam_user_text_regexp){
+                                    if(scam_induction_spam_user_text_regexp && typeof cslt_tweet_info_obj.user_data.description === "string"){
                                         if(scam_induction_spam_user_text_regexp.test(cslt_tweet_info_obj.user_data.description)){
                                             //console.log("ScamInductionDescription=>"+cslt_tweet_info_obj.text)
                                             cslt_target_tweet_elem.setAttribute("cslt_hide_flag", "true");
@@ -1054,7 +1054,7 @@ function main(filter_url, imp_filter_url) {
                                 }
                                 //プロフィール文空白アカウント非表示
                                 if(cslp_settings.blank_profile_hide){
-                                    if(cslt_tweet_info_obj.user_data.description == ""){
+                                    if(cslt_tweet_info_obj.user_data.description === ""){
                                         //console.log("ProfileDescriptionBlank=>"+cslt_tweet_info_obj.text)
                                         cslt_target_tweet_elem.setAttribute("cslt_hide_flag", "true");
                                         cslt_target_tweet_elem.textContent = "";
@@ -1293,7 +1293,8 @@ function main(filter_url, imp_filter_url) {
                                                 }
                                             }
                                             //返信本文ユーザープロフィール文チェック
-                                            if (affiliate_text_regexp.test(cslt_tweet_info_obj.user_data.description) || affiliate_user_text_regexp.test(cslt_tweet_info_obj.user_data.description)) {
+                                            const user_desc = cslt_tweet_info_obj.user_data.description;
+                                            if (typeof user_desc === "string" && (affiliate_text_regexp.test(user_desc) || affiliate_user_text_regexp.test(user_desc))) {
                                                 //console.log("AffiliateStrictUserDescriptionText=>"+cslt_tweet_info_obj.text)
                                                 cslt_target_tweet_elem.setAttribute("cslt_hide_flag", "true");
                                                 cslt_target_tweet_elem.textContent = "";
@@ -1303,7 +1304,7 @@ function main(filter_url, imp_filter_url) {
                                             if (cslt_tweet_info_obj.quoted_obj != null) {
                                                 let affiliate_check_quoted_text = cslt_tweet_info_obj.quoted_obj.text.replace(/@\w+\s*/g, "");
                                                 //引用のプロフィール文が空白の場合
-                                                if(cslt_tweet_info_obj.quoted_obj.user_data.description == ""){
+                                                if(cslt_tweet_info_obj.quoted_obj.user_data.description === ""){
                                                     //console.log("AffiliateStrictQuotedProfileDescriptionBlank=>"+cslt_tweet_info_obj.text)
                                                     cslt_target_tweet_elem.setAttribute("cslt_hide_flag", "true");
                                                     cslt_target_tweet_elem.textContent = "";
@@ -1331,7 +1332,8 @@ function main(filter_url, imp_filter_url) {
                                                     continue;
                                                 }
                                                 //引用返信ユーザー
-                                                if (affiliate_text_regexp.test(cslt_tweet_info_obj.quoted_obj.user_data.description) || affiliate_user_text_regexp.test(cslt_tweet_info_obj.quoted_obj.user_data.description)) {
+                                                const quoted_desc = cslt_tweet_info_obj.quoted_obj.user_data.description;
+                                                if (typeof quoted_desc === "string" && (affiliate_text_regexp.test(quoted_desc) || affiliate_user_text_regexp.test(quoted_desc))) {
                                                     //console.log("AffiliateStrictUserDescriptionText=>"+cslt_tweet_info_obj.text)
                                                     cslt_target_tweet_elem.setAttribute("cslt_hide_flag", "true");
                                                     cslt_target_tweet_elem.textContent = "";
@@ -1343,7 +1345,8 @@ function main(filter_url, imp_filter_url) {
                                                 let quoted_video_user_hide_flag = false;
                                                 for (let video_index = 0; video_index < cslt_tweet_info_obj.tweet_video_info.length; video_index++) {
                                                     if(cslt_tweet_info_obj.tweet_video_info[video_index]?.video_source_user_info != undefined){
-                                                        if (affiliate_user_text_regexp.test(cslt_tweet_info_obj.tweet_video_info[video_index].video_source_user_info.user_data.description)||affiliate_text_regexp.test(cslt_tweet_info_obj.tweet_video_info[video_index].video_source_user_info.user_data.description)||cslt_tweet_info_obj.tweet_video_info[video_index].video_source_user_info.user_data.description == "") {
+                                                        const video_desc = cslt_tweet_info_obj.tweet_video_info[video_index].video_source_user_info.user_data.description;
+                                                        if (typeof video_desc === "string" && (affiliate_user_text_regexp.test(video_desc) || affiliate_text_regexp.test(video_desc) || video_desc === "")) {
                                                             //console.log("AffiliateStrictVideoQuotedUserDescriptionText=>"+cslt_tweet_info_obj.text)
                                                             quoted_video_user_hide_flag = true;
                                                             cslt_target_tweet_elem.setAttribute("cslt_hide_flag", "true");
@@ -1467,7 +1470,7 @@ function main(filter_url, imp_filter_url) {
                                     const replace_emoji_regexp = /[\p{Emoji_Presentation}\p{Extended_Pictographic}\uFE0F]/gu;
                                     //絵文字を排除
                                     const delete_emoji_user_name = cslt_tweet_info_obj.user_data.name.replace(replace_emoji_regexp, "");
-                                    const delete_emoji_user_profile = cslt_tweet_info_obj.user_data.description.replace(replace_emoji_regexp, "");
+                                    const delete_emoji_user_profile = cslt_tweet_info_obj.user_data.description?.replace(replace_emoji_regexp, "");
                                     const delete_emoji_text = cslt_tweet_info_obj.text.replace(replace_emoji_regexp, "");
                                     //アラビア文字等ユーザー対象有効時
                                     if (cslp_settings.arabic_user_reply_block == true) {
@@ -1479,7 +1482,7 @@ function main(filter_url, imp_filter_url) {
                                         }
                                     }
                                     //ユーザーアカウントプロフィールテキストチェック
-                                    if (cslp_settings.arabic_user_profile_text_block) {
+                                    if (cslp_settings.arabic_user_profile_text_block && delete_emoji_user_profile != null) {
                                         if (arabic_regexp.test(delete_emoji_user_profile)) {
                                             //console.log("ArabicUserDescription=>" + cslt_tweet_info_obj.text)
                                             cslt_target_tweet_elem.setAttribute("cslt_hide_flag", "true");
@@ -1497,7 +1500,7 @@ function main(filter_url, imp_filter_url) {
                                     //引用チェック
                                     if (cslt_tweet_info_obj.quoted_obj != null) {
                                         const delete_emoji_quoted_user_name = cslt_tweet_info_obj.quoted_obj.user_data.name.replace(replace_emoji_regexp, "");
-                                        const delete_emoji_quoted_user_profile = cslt_tweet_info_obj.quoted_obj.user_data.description.replace(replace_emoji_regexp, "");
+                                        const delete_emoji_quoted_user_profile = cslt_tweet_info_obj.quoted_obj.user_data.description?.replace(replace_emoji_regexp, "");
                                         const delete_emoji_quoted_text = cslt_tweet_info_obj.quoted_obj.text.replace(replace_emoji_regexp, "");
                                         //引用内ユーザー名チェック
                                         if (cslp_settings.arabic_user_reply_block == true) {
@@ -1509,7 +1512,7 @@ function main(filter_url, imp_filter_url) {
                                             }
                                         }
                                         //引用内のユーザー説明文チェック
-                                        if (arabic_regexp.test(delete_emoji_quoted_user_profile)) {
+                                        if (delete_emoji_quoted_user_profile != null && arabic_regexp.test(delete_emoji_quoted_user_profile)) {
                                             //console.log("ArabicUserQuotedDescription=>" + cslt_tweet_info_obj.text)
                                             cslt_target_tweet_elem.setAttribute("cslt_hide_flag", "true");
                                             cslt_target_tweet_elem.textContent = "";

--- a/content.js
+++ b/content.js
@@ -1673,14 +1673,14 @@ function main(filter_url, imp_filter_url) {
 
                 /* MutationObserverによる監視 */
                 if (JSON.parse(cslp_settings.filter) == true) {
-                    const observer = new MutationObserver(run)
+                    const observer = new MutationObserver(run);
                     observer.observe(target_elem, {
                         childList: true,
                         attributes: true,
                         characterData: true,
                         subtree: true,
-                        attributeOldValue: true,
-                        characterDataOldValue: true
+                        attributeOldValue: false,
+                        characterDataOldValue: false
                     });
                 }
                 /* 以下非表示以外の機能用関数 */

--- a/content.js
+++ b/content.js
@@ -243,6 +243,7 @@ a[data-cslt-is-spam]{
     color: #fff;
     border-radius: 5px;
     font-size: 0.8rem;
+    font-family: system-ui;
     line-height: 1.3;
 }
 [data-cslt-is-spam]:has(> [data-testid="card.wrapper"]) {

--- a/content.js
+++ b/content.js
@@ -206,6 +206,23 @@ document.head.insertAdjacentHTML("beforeend", `
 .cslt_report_icon_notification_wrap .cslt_report_icon{
     margin-left: 10px;
 }
+
+.cslt_spam_link_found{
+    position: absolute;
+    z-index: 19;
+    display: inline-flex;
+    align-items: center;
+    text-align: center;
+    justify-content: center;
+    background-color: rgba(0,0,0,0.75);
+    color: #fff;
+    font-size: 16px;
+    font-family: system-ui;
+    cursor: default;
+}
+a[data-cslt-is-spam]{
+    pointer-events: none;
+}
 </style>
 `);
 
@@ -447,7 +464,7 @@ function main(filter_url, imp_filter_url) {
                 let target_elem = document.getElementById("react-root");
                 if(!target_elem){
                     //新クライアントの場合
-                    target_elem = document.querySelector('main');
+                    target_elem = document.body;
                     is_new_client = true;
                 }
                 //Write Latest Version
@@ -1538,45 +1555,11 @@ function main(filter_url, imp_filter_url) {
                         /*元ツイート以外にも適用するにはここから記述*/
                         //ナイト系スパム対策
                         if (cslp_settings.night_spam_block == true && !is_follow_page() && !is_status_rt() && processing_following_user_exclusion_flag && window.location.search.match(/f=user/g) == null) {
+                            cslt_target_tweet_elem.setAttribute("cslt_night_spam_processed_flag", "true");
                             //テキスト内のURLチェック
                             const night_spam_text_urls = cslt_tweet_info_obj.text.replaceAll('\n', ' ').match(/((https?:\/\/|www\.)[^\s/$.?#].[^\s]*)/gi);
                             let night_spam_processed_flag = false;
                             //console.log(night_spam_text_urls)
-                            if (night_spam_text_urls != null && cslt_tweet_info_obj.attached_urls != null) {
-                                for (let text_urls_index = 0; text_urls_index < cslt_tweet_info_obj.attached_urls.length; text_urls_index++) {
-                                    const expanded_url = cslt_tweet_info_obj.attached_urls[text_urls_index].expanded_url;
-                                    const tco_url = cslt_tweet_info_obj.attached_urls[text_urls_index].url;
-                                    if (night_spam_text_urls[text_urls_index] == tco_url) {
-                                        if (block_regexp.test(expanded_url)) {
-                                            //console.log("NightSpamText=>"+cslt_tweet_info_obj.text)
-                                            if (cslp_settings.hit_del == true && !cslt_tweet_info_obj.is_root_tweet) {
-                                                //ヒットツイート非表示有効&元ツイートでない場合非表示
-                                                night_spam_processed_flag = true;
-                                                cslt_target_tweet_elem.setAttribute("cslt_hide_flag", "true");
-                                                cslt_target_tweet_elem.textContent = "";
-                                                break;
-                                            } else {
-                                                //ヒットツイート非表示無効
-                                                const night_spam_text_url_nodelist = cslt_target_tweet_elem.querySelectorAll(`div[data-testid="tweetText"] a[href="${tco_url}"]`);
-                                                let ins_html;
-                                                for (let spam_link_index = 0; spam_link_index < night_spam_text_url_nodelist.length; spam_link_index++) {
-                                                    if (night_spam_text_url_nodelist[spam_link_index].offsetWidth < 230) {
-                                                        ins_html = `<div style="position: absolute;z-index: 99999;width: ${night_spam_text_url_nodelist[spam_link_index].offsetWidth + 1}px;height: ${night_spam_text_url_nodelist[spam_link_index].offsetHeight + 5}px;max-height:25px;display: inline-flex;align-items: center;text-align: center;justify-content: center;background-color: rgba(0,0,0,0.75);color: #fff;font-size: 0.5rem;"><p>スパム</p></div>`;
-                                                    } else {
-                                                        ins_html = `<div class="cslt_spam_link_found" style="position: absolute;z-index: 99999;width: ${night_spam_text_url_nodelist[spam_link_index].offsetWidth + 1}px;height: ${night_spam_text_url_nodelist[spam_link_index].offsetHeight + 5}px;max-height:25px;display: inline-flex;align-items: center;text-align: center;justify-content: center;background-color: rgba(0,0,0,0.75);color: #fff;"><p>スパムを検出!&nbsp;(${night_spam_text_url_nodelist[spam_link_index].textContent.match(/\/\/([^/]*)/)[1]})</p></div>`;
-                                                    }
-                                                    night_spam_text_url_nodelist[spam_link_index].style.whiteSpace = "nowrap";
-                                                    night_spam_text_url_nodelist[spam_link_index].insertAdjacentHTML("beforebegin", ins_html);
-                                                    if (cslp_settings.hit_url_copy == true) {
-                                                        copy_url(cslt_target_tweet_elem);
-                                                    }
-                                                }
-                                                night_spam_processed_flag = true;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
                             //TwitterCard処理
                             if (cslt_tweet_info_obj.tw_card_obj != null) {
                                 if (block_regexp.test(cslt_tweet_info_obj.tw_card_obj.domain)) {
@@ -1586,10 +1569,23 @@ function main(filter_url, imp_filter_url) {
                                         cslt_target_tweet_elem.setAttribute("cslt_hide_flag", "true");
                                         cslt_target_tweet_elem.textContent = "";
                                     } else {
-                                        const ins_html = `<div class="cslt_spam_link_found" style="position: absolute;z-index: 99999;width: 100%;height: 101%;display: flex;align-items: center;text-align: center;justify-content: center;background-color: rgba(0,0,0,0.75);color: #fff;border-radius: 5px 5px 5px 5px;"><p>スパムを検出!<br>ヒットしたURL:${cslt_tweet_info_obj.tw_card_obj.domain}<br>クリックでツイートを開く</p></div>`;
+                                        let ins_html = `<div class="cslt_spam_link_found" style="position: absolute;z-index: 99999;width: 100%;height: 101%;display: flex;align-items: center;text-align: center;justify-content: center;background-color: rgba(0,0,0,0.75);color: #fff;border-radius: 5px 5px 5px 5px;"><p>スパムを検出!<br>ヒットしたURL:${cslt_tweet_info_obj.tw_card_obj.domain}<br>クリックでツイートを開く</p></div>`;
                                         //cslt_target_tweet_elem.querySelector(`div[data-testid="card.wrapper"]`).insertAdjacentHTML("beforebegin", ins_html);
-                                        const night_spam_twitter_card_elem = cslt_target_tweet_elem.querySelector(`div[aria-labelledby][id]`);
+                                        let night_spam_twitter_card_elem = cslt_target_tweet_elem.querySelector(`div[aria-labelledby][id], a[href="${cslt_tweet_info_obj.tw_card_obj.card_url}"], button:has(img[src*="card_img"])`);
                                         if (night_spam_twitter_card_elem != null) {
+                                            night_spam_twitter_card_elem.dataset.csltIsSpam = true;
+                                            if (is_new_client) {
+                                                //ボタンのタイプのCardでクリックしても動作しないようにする
+                                                if(night_spam_twitter_card_elem.tagName === "BUTTON") {
+                                                    night_spam_twitter_card_elem.disabled = true;
+                                                }
+                                                //通常タイプのCard(カード本体と提供元リンクが兄弟の場合のみ親へ繰り上げる)
+                                                if (night_spam_twitter_card_elem.tagName === "A" && night_spam_twitter_card_elem.parentElement.querySelectorAll(`a[href="${cslt_tweet_info_obj.tw_card_obj.card_url}"]`).length > 1) {
+                                                    night_spam_twitter_card_elem = night_spam_twitter_card_elem.parentElement;
+                                                }
+                                                night_spam_twitter_card_elem.style.position = "relative";
+                                                ins_html = `<div class="cslt_spam_link_found" style="inset:0;border-radius:5px;"><p>スパムを検出!<br>ヒットしたURL:${cslt_tweet_info_obj.tw_card_obj.domain}<br>クリックでツイートを開く</p></div>`;
+                                            }
                                             night_spam_twitter_card_elem.insertAdjacentHTML("afterbegin", ins_html);
                                             if (cslp_settings.hit_url_copy == true) {
                                                 copy_url(cslt_target_tweet_elem);
@@ -1610,9 +1606,18 @@ function main(filter_url, imp_filter_url) {
                                         cslt_target_tweet_elem.setAttribute("cslt_hide_flag", "true");
                                         cslt_target_tweet_elem.textContent = "";
                                     } else {
-                                        const ins_html = `<div class="cslt_spam_link_found" style="position: absolute;z-index: 99999;width: 100%;height: 101%;display: flex;align-items: center;text-align: center;justify-content: center;background-color: rgba(0,0,0,0.75);color: #fff;border-radius: 5px 5px 5px 5px;"><p>スパムを検出!<br>ヒットしたURL:${video_card_url.host}<br>クリックでツイートを開く</p></div>`;
-                                        const night_spam_twitter_card_elem = cslt_target_tweet_elem.querySelector(`div[aria-labelledby][id]`);
+                                        let ins_html = `<div class="cslt_spam_link_found" style="position: absolute;z-index: 99999;width: 100%;height: 101%;display: flex;align-items: center;text-align: center;justify-content: center;background-color: rgba(0,0,0,0.75);color: #fff;border-radius: 5px 5px 5px 5px;"><p>スパムを検出!<br>ヒットしたURL:${video_card_url.host}<br>クリックでツイートを開く</p></div>`;
+                                        let night_spam_twitter_card_elem = cslt_target_tweet_elem.querySelector(`div[aria-labelledby][id], a[href="${video_card_url_data.url}"]`);
                                         if (night_spam_twitter_card_elem != null) {
+                                            night_spam_twitter_card_elem.dataset.csltIsSpam = true;
+                                            if (is_new_client) {
+                                                //カード本体と提供元リンクが兄弟なので親へ繰り上げる
+                                                if (night_spam_twitter_card_elem.tagName === "A") {
+                                                    night_spam_twitter_card_elem = night_spam_twitter_card_elem.parentElement;
+                                                }
+                                                night_spam_twitter_card_elem.style.position = "relative";
+                                                ins_html = `<div class="cslt_spam_link_found" style="inset:0;border-radius:5px;"><p>スパムを検出!<br>ヒットしたURL:${video_card_url.host}<br>クリックでツイートを開く</p></div>`;
+                                            }
                                             night_spam_twitter_card_elem.insertAdjacentHTML("afterbegin", ins_html);
                                             if (cslp_settings.hit_url_copy == true) {
                                                 copy_url(cslt_target_tweet_elem);
@@ -1620,9 +1625,50 @@ function main(filter_url, imp_filter_url) {
                                         }
                                     }
                                 }
+                                night_spam_processed_flag = true;
+                            }
+                            //通常のリンク
+                            if (night_spam_text_urls != null && cslt_tweet_info_obj.attached_urls != null) {
+                                for (let text_urls_index = 0; text_urls_index < cslt_tweet_info_obj.attached_urls.length; text_urls_index++) {
+                                    const expanded_url = cslt_tweet_info_obj.attached_urls[text_urls_index].expanded_url;
+                                    const tco_url = cslt_tweet_info_obj.attached_urls[text_urls_index].url;
+                                    if (night_spam_text_urls[text_urls_index] == tco_url) {
+                                        if (block_regexp.test(expanded_url)) {
+                                            //console.log("NightSpamText=>"+cslt_tweet_info_obj.text)
+                                            if (cslp_settings.hit_del == true && !cslt_tweet_info_obj.is_root_tweet) {
+                                                //ヒットツイート非表示有効&元ツイートでない場合非表示
+                                                night_spam_processed_flag = true;
+                                                cslt_target_tweet_elem.setAttribute("cslt_hide_flag", "true");
+                                                cslt_target_tweet_elem.textContent = "";
+                                                break;
+                                            } else {
+                                                //ヒットツイート非表示無効
+                                                const night_spam_text_url_nodelist = cslt_target_tweet_elem.querySelectorAll(`div[data-testid="tweetText"] a[href="${tco_url}"], a[href="${tco_url}"], a[href="${expanded_url}"]`);
+                                                let ins_html;
+                                                const host = expanded_url.match(/\/\/([^/]*)/)?.[1] ?? "不明";
+                                                for (let spam_link_index = 0; spam_link_index < night_spam_text_url_nodelist.length; spam_link_index++) {
+                                                    if (night_spam_text_url_nodelist[spam_link_index].closest("[data-cslt-is-spam]")) continue;
+                                                    night_spam_text_url_nodelist[spam_link_index].dataset.csltIsSpam = true;
+                                                    const rect = night_spam_text_url_nodelist[spam_link_index].getClientRects()[0];
+                                                    if (rect == null) continue;
+                                                    if (rect.width < 230) {
+                                                        ins_html = `<div class="cslt_spam_link_found" style="inset:0;font-size:0.5rem;"><p>スパム</p></div>`;
+                                                    } else {
+                                                        ins_html = `<div class="cslt_spam_link_found" style="inset:0;"><p>スパムを検出!&nbsp;(${host})</p></div>`;
+                                                    }
+                                                    night_spam_text_url_nodelist[spam_link_index].style.position = "relative";
+                                                    night_spam_text_url_nodelist[spam_link_index].insertAdjacentHTML("afterbegin", ins_html);
+                                                }
+                                                if (cslp_settings.hit_url_copy == true) {
+                                                    copy_url(cslt_target_tweet_elem);
+                                                }
+                                                night_spam_processed_flag = true;
+                                            }
+                                        }
+                                    }
+                                }
                             }
                             if (night_spam_processed_flag) {
-                                cslt_target_tweet_elem.setAttribute("cslt_night_spam_processed_flag", "true");
                                 continue;
                             }
                         }

--- a/content.js
+++ b/content.js
@@ -450,7 +450,6 @@ function main(filter_url, imp_filter_url) {
                     target_elem = document.querySelector('main');
                     is_new_client = true;
                 }
-                console.log(target_elem)
                 //Write Latest Version
                 cslp_settings.filter_update = json[0].developer_update;
                 cslp_settings.filter_link = json[0].thanks_link;

--- a/content.js
+++ b/content.js
@@ -169,32 +169,6 @@ document.head.insertAdjacentHTML("beforeend", `
 .cslt_report_fail:hover{
     filter: brightness(0) saturate(100%) invert(46%) sepia(95%) saturate(2856%) hue-rotate(1deg) brightness(93%) contrast(102%);
 }
-.cslt_message_wrap{
-    display: none;
-    position: fixed;
-    bottom: 4rem;
-    width: 100vw;
-    height: 2rem;
-    z-index: 9999;
-    align-items: center;
-    justify-content: center;
-}
-.cslt_message_content{
-    display: flex;
-    height: 100%;
-    background: #1d9bf0;
-    color: white;
-    border-radius: 5px;
-    text-align: center;
-    vertical-align: middle;
-    align-content: center;
-    justify-content: center;
-    align-items: center;
-    font-family: system-ui;
-}
-.cslt_message_content span{
-    margin: 0 1rem 0 1rem;
-}
 .cslt_block_mute_list_func_btn{
     display: flex;
     height: 3rem;
@@ -245,8 +219,7 @@ const tweet_info_script = document.createElement('script');
 tweet_info_script.src = chrome.runtime.getURL("cslt_tweet_ctrl.js");
 document.head.appendChild(tweet_info_script);
 
-//メッセージパネル挿入
-document.body.insertAdjacentHTML("afterbegin", '<div class="cslt_message_wrap"><div class="cslt_message_content"><span class="cslt_message_span">CSLTメッセージ</span></div></div>');
+//メッセージパネル初期化
 const systemMessagePanel = cslt_message_display_init();
 //
 chrome.storage.local.get("cslp_settings", function (value) {

--- a/content.js
+++ b/content.js
@@ -723,7 +723,6 @@ function main(filter_url, imp_filter_url) {
                     const not_selector = `:not([cslt_tweet_info_mytweet_flag="true"],[cslt_white_list_user],[cslt_hide_flag="true"],[cslt_blue_bypass_flag="true"],[cslt_night_spam_processed_flag="true"],[cslt_process_ok="true"],[cslt_temp_fail_report_flag="fail_tweet"])`;
                     const target_selector = `div[data-testid="cellInnerDiv"][cslt_tweet_info]${not_selector},li[cslt_tweet_info]${not_selector}`;//,[cslt_report_btn_set_flag="true"] ${cslt_exclusion_css_flag}
                     const target_tweet_element = target_elem.querySelectorAll(target_selector);
-                    console.log(target_tweet_element)
                     /* 非表示等動作 */
                     /* TIPS:新しい非表示機能付けたけど画面が固まってしまう場合、フラグが立っていない可能性があります！
                     非表示処理後は「cslt_hide_flag」の値を「true」にしたフラグを立てましょう。
@@ -769,7 +768,7 @@ function main(filter_url, imp_filter_url) {
                                     continue;
                                 }
                             }
-                            /* リツイート欄等では非表示機能を無効化 */
+                            /* リツイートやフォロー欄等では非表示機能を無効化 */
                             if (!is_status_rt() && processing_following_user_exclusion_flag) {
                                 //ホワイトリスト処理
                                 if (cslp_settings.user_register_whitelist.length != 0) {
@@ -1717,6 +1716,7 @@ function main(filter_url, imp_filter_url) {
                     if (is_follow_page() || is_status_rt() && cslp_settings.oneclick_report_follow_list == true || window.location.search.match(/f=user/g)?.length == 1 && cslp_settings.oneclick_report_follow_list == true) {
                         if (cslp_settings.imp_user_block == true && cslp_settings.follow_list_imp_find_user == true) {
                             const follower_user_id = input_element.querySelector('[data-testid="UserCell"] a[role="link"]')?.href.replace(/(https:\/\/x.com\/|https:\/\/twitter.com\/)/g, "");
+                            //TODO: 新クライアントの通知とフォロー画面が確認できていないので、今後対応させる
                             if (imp_user_block_list_regexp.test(follower_user_id) && input_element.querySelector('[data-testid="UserCell"]').getAttribute("cslt_flag") != "follower_imp_ok") {
                                 input_element.querySelector('[data-testid="UserCell"]').setAttribute("cslt_flag", "follower_imp_ok");
                                 input_element.querySelector('[data-testid="UserCell"]').style.backgroundColor = "#ffb9ad";

--- a/cslt_tweet_ctrl.js
+++ b/cslt_tweet_ctrl.js
@@ -456,9 +456,16 @@
                             }
                             if(tweet_info_other?.in_reply_to_status_id_str != undefined){
                                 is_reply_other = true;
-                                reply_user_data_other_obj = {
-                                    user_id: tweet_info_other?.in_reply_to_user.id_str,
-                                    scr_name: tweet_info_other?.in_reply_to_user.screen_name
+                                if(tweet_info_other?.in_reply_to_user){
+                                    reply_user_data_other_obj = {
+                                        user_id: tweet_info_other?.in_reply_to_user.id_str,
+                                        scr_name: tweet_info_other?.in_reply_to_user.screen_name,
+                                    }
+                                }else{
+                                    reply_user_data_other_obj = {
+                                        user_id: tweet_info_other?.in_reply_to_user_id_str,
+                                        scr_name: tweet_info_other?.in_reply_to_screen_name,
+                                    }
                                 }
                             }
                             if(tweet_info_other?.card?.binding_values?.domain?.string_value != undefined){

--- a/cslt_tweet_ctrl.js
+++ b/cslt_tweet_ctrl.js
@@ -1,701 +1,709 @@
-console.log("CSLT Analyze Script is Working!");
-//[role="group"]から一つ上の要素でも取れる。将来的に取れなくなったらそこから取るようにする
-function get_tw_userdata(input_element, mode){
-    const input_pr_array = Object.getOwnPropertyNames(input_element);
-    const props_pr_name = input_pr_array.find((input)=>input.includes('__reactProps$'));
-    const props_data = input_element[props_pr_name];
-    switch(mode){
-        case "user_page":
-            return props_data?.children[0][1]?.props?.children[0]?.props?.children[1]?.props?.user;
-        case "user_page_ids":
-            const user_obj = {
-                userId: props_data?.children[0][1]?.props?.children[0]?.props?.children[1]?.props.userId, 
-                screen_name: props_data?.children[0][1]?.props?.children[0]?.props?.children[0]?.props?.screenName
-            };
-            return user_obj;
-        case "reply":
-            return props_data?.children[1]?.props?.retweetWithCommentLink?.state?.quotedStatus;
-        case "login_user":
-            return props_data?.children?.props?.children?.props?.children[1]?.props?.children?.props?.children?.props?.children?.props?.value?.loggedInUserId;
-        case "user_page_info":
-            return props_data?.children[0]?.props?.children[1]?.props?.user;
-        case "settings_block_mute_user_id":
-            return props_data?.children[0][1]?.props?.children[0]?.props?.children[1]?.props?.userId;
-        case "notification_like_rt":
-            return props_data?.children[0][1]?.props?.children?.props?.children[0]?.props?.children?.props?.users
+(function (){
+    //新しいクライアント上で動作させているかを検出する
+    if (window.__TSR_ROUTER__){
+        console.log("Use new client");
+        return;
+    };
+
+    console.log("CSLT Analyze Script is Working!");
+    //[role="group"]から一つ上の要素でも取れる。将来的に取れなくなったらそこから取るようにする
+    function get_tw_userdata(input_element, mode){
+        const input_pr_array = Object.getOwnPropertyNames(input_element);
+        const props_pr_name = input_pr_array.find((input)=>input.includes('__reactProps$'));
+        const props_data = input_element[props_pr_name];
+        switch(mode){
+            case "user_page":
+                return props_data?.children[0][1]?.props?.children[0]?.props?.children[1]?.props?.user;
+            case "user_page_ids":
+                const user_obj = {
+                    userId: props_data?.children[0][1]?.props?.children[0]?.props?.children[1]?.props.userId, 
+                    screen_name: props_data?.children[0][1]?.props?.children[0]?.props?.children[0]?.props?.screenName
+                };
+                return user_obj;
+            case "reply":
+                return props_data?.children[1]?.props?.retweetWithCommentLink?.state?.quotedStatus;
+            case "login_user":
+                return props_data?.children?.props?.children?.props?.children[1]?.props?.children?.props?.children?.props?.children?.props?.value?.loggedInUserId;
+            case "user_page_info":
+                return props_data?.children[0]?.props?.children[1]?.props?.user;
+            case "settings_block_mute_user_id":
+                return props_data?.children[0][1]?.props?.children[0]?.props?.children[1]?.props?.userId;
+            case "notification_like_rt":
+                return props_data?.children[0][1]?.props?.children?.props?.children[0]?.props?.children?.props?.users
+        }
     }
-}
-const root_elem = document.querySelector('#react-root');
-//ログインユーザーID出力関数
-function login_userid(){
-    return document.querySelector('script[type="text/javascript"][charset="utf-8"][nonce]').textContent.match(/"screen_name":"(.*?)"/)[1];
-}
-const tweet_obs = new MutationObserver(function(){
-    //console.log("obs_load");
-    let tweet_elem = null;
-    let page_mode = null;
-    const page_path = window.location.pathname.split("/")[2];
-    const page_path_status = window.location.pathname.split("/")[4];
-    switch (page_path) {
-        case 'status':
-            //tweet_elem = document.querySelectorAll('main div[data-testid="cellInnerDiv"] article[data-testid="tweet"][tabindex="0"] div[aria-label][role="group"][id]:not([cslt_tweet_process="ok"])');
-            tweet_elem = document.querySelectorAll('#react-root div[data-testid="cellInnerDiv"] article[data-testid="tweet"] div[aria-label][role="group"][id]:not([cslt_tweet_process="ok"])');
-            page_mode = 'status';
-            break;
-        case 'verified_followers':
-        case 'followers':    
-        case 'following':
-            tweet_elem = document.querySelectorAll('section[role="region"] div[data-testid="cellInnerDiv"] div[role="button"][tabindex="0"][data-testid="UserCell"]:not([cslt_tweet_process="ok"]), section[role="region"] div[data-testid="cellInnerDiv"] [type="button"][data-testid="UserCell"]:not([cslt_tweet_process="ok"])');
-            page_mode = 'followers';
-            break;
-        case 'communities':
-            tweet_elem = document.querySelectorAll('main div[data-testid="cellInnerDiv"] article[data-testid="tweet"][tabindex="0"] div[aria-label][role="group"][id]:not([cslt_tweet_process="ok"])');
-            page_mode = 'communities';
-            break;
-        default:
-            if(window.location.search.match(/f=user/g)?.length == 1){
-                //ユーザー検索ページの場合
+    const root_elem = document.querySelector('#react-root');
+    //ログインユーザーID出力関数
+    function login_userid(){
+        return document.querySelector('script[type="text/javascript"][charset="utf-8"][nonce]').textContent.match(/"screen_name":"(.*?)"/)[1];
+    }
+    const tweet_obs = new MutationObserver(function(){
+        //console.log("obs_load");
+        let tweet_elem = null;
+        let page_mode = null;
+        const page_path = window.location.pathname.split("/")[2];
+        const page_path_status = window.location.pathname.split("/")[4];
+        switch (page_path) {
+            case 'status':
+                //tweet_elem = document.querySelectorAll('main div[data-testid="cellInnerDiv"] article[data-testid="tweet"][tabindex="0"] div[aria-label][role="group"][id]:not([cslt_tweet_process="ok"])');
+                tweet_elem = document.querySelectorAll('#react-root div[data-testid="cellInnerDiv"] article[data-testid="tweet"] div[aria-label][role="group"][id]:not([cslt_tweet_process="ok"])');
+                page_mode = 'status';
+                break;
+            case 'verified_followers':
+            case 'followers':    
+            case 'following':
                 tweet_elem = document.querySelectorAll('section[role="region"] div[data-testid="cellInnerDiv"] div[role="button"][tabindex="0"][data-testid="UserCell"]:not([cslt_tweet_process="ok"]), section[role="region"] div[data-testid="cellInnerDiv"] [type="button"][data-testid="UserCell"]:not([cslt_tweet_process="ok"])');
                 page_mode = 'followers';
                 break;
-            }else{
-                //その他の場合(通知欄も検出対象)
-                tweet_elem = document.querySelectorAll('main div[data-testid="cellInnerDiv"] article[data-testid="tweet"][tabindex="0"] div[aria-label][role="group"][id]:not([cslt_tweet_process="ok"]), article[data-testid="notification"]:not([cslt_tweet_process="ok"])');
-                page_mode = 'other';
+            case 'communities':
+                tweet_elem = document.querySelectorAll('main div[data-testid="cellInnerDiv"] article[data-testid="tweet"][tabindex="0"] div[aria-label][role="group"][id]:not([cslt_tweet_process="ok"])');
+                page_mode = 'communities';
                 break;
-            }
-            
-    }
-    //ツイートのリツイート、いいね画面の場合
-    if(page_path == 'status' && page_path_status == 'retweets' || page_path_status == 'likes'){
-        tweet_elem = document.querySelectorAll('section[role="region"] div[data-testid="cellInnerDiv"] div[role="button"][tabindex="0"][data-testid="UserCell"]:not([cslt_tweet_process="ok"]), section[role="region"] div[data-testid="cellInnerDiv"] [type="button"][data-testid="UserCell"]:not([cslt_tweet_process="ok"])');
-        //ユーザーが出て来るだけなのでフォロワー欄扱いで処理
-        page_mode = 'followers';
-    }
-    //設定のブロックかミュートのページの場合
-    /*if(window.location.pathname.split("/")[1] == 'settings' && page_path == 'blocked' || page_path == 'muted'){
-        tweet_elem = document.querySelectorAll('section[role="region"] [data-testid="UserCell"][type="button"]:not([cslt_block_mute_list_user_id])');
-        if(tweet_elem != null){
-            page_mode = 'settings_block_mute';
+            default:
+                if(window.location.search.match(/f=user/g)?.length == 1){
+                    //ユーザー検索ページの場合
+                    tweet_elem = document.querySelectorAll('section[role="region"] div[data-testid="cellInnerDiv"] div[role="button"][tabindex="0"][data-testid="UserCell"]:not([cslt_tweet_process="ok"]), section[role="region"] div[data-testid="cellInnerDiv"] [type="button"][data-testid="UserCell"]:not([cslt_tweet_process="ok"])');
+                    page_mode = 'followers';
+                    break;
+                }else{
+                    //その他の場合(通知欄も検出対象)
+                    tweet_elem = document.querySelectorAll('main div[data-testid="cellInnerDiv"] article[data-testid="tweet"][tabindex="0"] div[aria-label][role="group"][id]:not([cslt_tweet_process="ok"]), article[data-testid="notification"]:not([cslt_tweet_process="ok"])');
+                    page_mode = 'other';
+                    break;
+                }
+
         }
-    }*/
-    //
-    for (let tweet_index = 0; tweet_index < tweet_elem.length; tweet_index++) {
-        if(tweet_elem[tweet_index] != null){
-            let video_info = [];
-            switch (page_mode) {
-                case 'status':
-                    //console.log("status")
-                    const tweet_info_reply = get_tw_userdata(tweet_elem[tweet_index], "reply");
+        //ツイートのリツイート、いいね画面の場合
+        if(page_path == 'status' && page_path_status == 'retweets' || page_path_status == 'likes'){
+            tweet_elem = document.querySelectorAll('section[role="region"] div[data-testid="cellInnerDiv"] div[role="button"][tabindex="0"][data-testid="UserCell"]:not([cslt_tweet_process="ok"]), section[role="region"] div[data-testid="cellInnerDiv"] [type="button"][data-testid="UserCell"]:not([cslt_tweet_process="ok"])');
+            //ユーザーが出て来るだけなのでフォロワー欄扱いで処理
+            page_mode = 'followers';
+        }
+        //設定のブロックかミュートのページの場合
+        /*if(window.location.pathname.split("/")[1] == 'settings' && page_path == 'blocked' || page_path == 'muted'){
+            tweet_elem = document.querySelectorAll('section[role="region"] [data-testid="UserCell"][type="button"]:not([cslt_block_mute_list_user_id])');
+            if(tweet_elem != null){
+                page_mode = 'settings_block_mute';
+            }
+        }*/
+        //
+        for (let tweet_index = 0; tweet_index < tweet_elem.length; tweet_index++) {
+            if(tweet_elem[tweet_index] != null){
+                let video_info = [];
+                switch (page_mode) {
+                    case 'status':
+                        //console.log("status")
+                        const tweet_info_reply = get_tw_userdata(tweet_elem[tweet_index], "reply");
 
-                    //console.dir(tweet_info_reply)
+                        //console.dir(tweet_info_reply)
 
-                    if(tweet_info_reply != undefined){
-                        //報告用JSON生成
-                        let is_media_tweet = false;
-                        let is_promo_tweet = false;
-                        if(tweet_info_reply.extended_entities?.media != undefined){
-                            is_media_tweet = true;
-                        }
-                        if(tweet_info_reply.promoted_content != undefined){
-                            is_promo_tweet = true;
-                        }
-                        //動画・GIF情報取り出し
-                        if(is_media_tweet){
-                            const media_info_obj = tweet_info_reply.entities?.media;
-                            //console.log(media_info_obj)
-                            for (let index = 0; index < media_info_obj.length; index++) {
-                                if(media_info_obj[index].type == "video"){
-                                    //console.log(media_info_obj[index])
-                                    let media_source_user_data = null;
-                                    if(media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy != undefined){
-                                        media_source_user_data = {
-                                            user_data:{
-                                                name: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.name, 
-                                                description: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.description,
-                                                user_id: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.id_str,
-                                                scr_name: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.screen_name,
-                                                all_tweet_count: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.statuses_count,
-                                                is_blue:media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.is_blue_verified,
-                                                location: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.location,
-                                                account_create_date: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.created_at
+                        if(tweet_info_reply != undefined){
+                            //報告用JSON生成
+                            let is_media_tweet = false;
+                            let is_promo_tweet = false;
+                            if(tweet_info_reply.extended_entities?.media != undefined){
+                                is_media_tweet = true;
+                            }
+                            if(tweet_info_reply.promoted_content != undefined){
+                                is_promo_tweet = true;
+                            }
+                            //動画・GIF情報取り出し
+                            if(is_media_tweet){
+                                const media_info_obj = tweet_info_reply.entities?.media;
+                                //console.log(media_info_obj)
+                                for (let index = 0; index < media_info_obj.length; index++) {
+                                    if(media_info_obj[index].type == "video"){
+                                        //console.log(media_info_obj[index])
+                                        let media_source_user_data = null;
+                                        if(media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy != undefined){
+                                            media_source_user_data = {
+                                                user_data:{
+                                                    name: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.name, 
+                                                    description: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.description,
+                                                    user_id: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.id_str,
+                                                    scr_name: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.screen_name,
+                                                    all_tweet_count: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.statuses_count,
+                                                    is_blue:media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.is_blue_verified,
+                                                    location: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.location,
+                                                    account_create_date: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.created_at
+                                                }
                                             }
                                         }
+                                        const media_info = {
+                                            type: media_info_obj[index].type,
+                                            duration_ms: media_info_obj[index].video_info.duration_millis,
+                                            video_raw: media_info_obj[index].video_info.variants.at(-1),
+                                            video_source_user_info:media_source_user_data
+                                        }
+                                        video_info.push(media_info);
                                     }
-                                    const media_info = {
-                                        type: media_info_obj[index].type,
-                                        duration_ms: media_info_obj[index].video_info.duration_millis,
-                                        video_raw: media_info_obj[index].video_info.variants.at(-1),
-                                        video_source_user_info:media_source_user_data
+                                    if(media_info_obj[index].type == "animated_gif"){
+                                        const media_info = {
+                                            type: media_info_obj[index].type,
+                                            duration_ms: null,
+                                            video_raw: media_info_obj[index].video_info.variants.at(-1),
+                                            video_source_user_info: null
+                                        }
+                                        video_info.push(media_info);
                                     }
-                                    video_info.push(media_info);
                                 }
-                                if(media_info_obj[index].type == "animated_gif"){
-                                    const media_info = {
-                                        type: media_info_obj[index].type,
-                                        duration_ms: null,
-                                        video_raw: media_info_obj[index].video_info.variants.at(-1),
-                                        video_source_user_info: null
-                                    }
-                                    video_info.push(media_info);
+                                if(video_info.length == 0){
+                                    video_info = null;
                                 }
-                            }
-                            if(video_info.length == 0){
+                            }else{
                                 video_info = null;
                             }
-                        }else{
-                            video_info = null;
-                        }
-                        const report_json_body = `{\"input_flow_data\":{\"requested_variant\":\"{\\\"client_app_id\\\":\\\"3033300\\\",\\\"client_location\\\":\\\"tweet:conversation_descendants:tweet\\\",\\\"client_referer\\\":\\\"${tweet_info_reply.permalink}\\\",\\\"is_media\\\":${is_media_tweet},\\\"is_promoted\\\":${is_promo_tweet},\\\"report_flow_id\\\":\\\"%cslt_random_uuid%\\\",\\\"reported_tweet_id\\\":\\\"${tweet_info_reply.id_str}\\\",\\\"reported_user_id\\\":\\\"${tweet_info_reply.user.id_str}\\\",\\\"source\\\":\\\"reporttweet\\\"}\",\"flow_context\":{\"debug_overrides\":{},\"start_location\":{\"location\":\"tweet\",\"tweet\":{\"tweet_id\":\"${tweet_info_reply.id_str}\"}}}},\"subtask_versions\":{\"action_list\":2,\"alert_dialog\":1,\"app_download_cta\":1,\"check_logged_in_account\":1,\"choice_selection\":3,\"contacts_live_sync_permission_prompt\":0,\"cta\":7,\"email_verification\":2,\"end_flow\":1,\"enter_date\":1,\"enter_email\":2,\"enter_password\":5,\"enter_phone\":2,\"enter_recaptcha\":1,\"enter_text\":5,\"enter_username\":2,\"generic_urt\":3,\"in_app_notification\":1,\"interest_picker\":3,\"js_instrumentation\":1,\"menu_dialog\":1,\"notifications_permission_prompt\":2,\"open_account\":2,\"open_home_timeline\":1,\"open_link\":1,\"phone_verification\":4,\"privacy_options\":1,\"security_key\":3,\"select_avatar\":4,\"select_banner\":2,\"settings_list\":7,\"show_code\":1,\"sign_up\":2,\"sign_up_review\":4,\"tweet_selection_urt\":1,\"update_users\":1,\"upload_media\":1,\"user_recommendations_list\":4,\"user_recommendations_urt\":1,\"wait_spinner\":3,\"web_modal\":1}}`;
-                        const user_report_json_body = `{\"input_flow_data\":{\"requested_variant\":\"{\\\"client_app_id\\\":\\\"3033300\\\",\\\"client_location\\\":\\\"profile:header:\\\",\\\"client_referer\\\":\\\"/${tweet_info_reply.user.screen_name}\\\",\\\"is_media\\\":false,\\\"is_promoted\\\":false,\\\"report_flow_id\\\":\\\"%cslt_random_uuid%\\\",\\\"reported_user_id\\\":\\\"${tweet_info_reply.user.id_str}\\\",\\\"source\\\":\\\"reportprofile\\\"}\",\"flow_context\":{\"debug_overrides\":{},\"start_location\":{\"location\":\"profile\",\"profile\":{\"profile_id\":\"${tweet_info_reply.user.id_str}\"}}}}}`;
-                        //ツイート情報オブジェクト生成
-                        let is_reply_root_tweet = false;
-                        let reply_quoted_obj = null;
-                        let reply_out_urls = null;
-                        let quoted_urls = null;
-                        let is_reply_status = false;
-                        let reply_user_data_status_obj = null;
-                        let reply_twitter_card_obj = null;
-                        let reply_twitter_card_unified_obj = null;
-                        let reply_blocked_by_flag = false;
-                        let reply_quoted_blocked_by_flag = false;
-                        if(tweet_info_reply.permalink == location.pathname){
-                            is_reply_root_tweet = true;
-                        }
-                        if(tweet_info_reply.quoted_status != undefined){
-                            if(tweet_info_reply.quoted_status?.entities?.urls?.length != 0){
-                                quoted_urls = tweet_info_reply.quoted_status.entities.urls;
+                            const report_json_body = `{\"input_flow_data\":{\"requested_variant\":\"{\\\"client_app_id\\\":\\\"3033300\\\",\\\"client_location\\\":\\\"tweet:conversation_descendants:tweet\\\",\\\"client_referer\\\":\\\"${tweet_info_reply.permalink}\\\",\\\"is_media\\\":${is_media_tweet},\\\"is_promoted\\\":${is_promo_tweet},\\\"report_flow_id\\\":\\\"%cslt_random_uuid%\\\",\\\"reported_tweet_id\\\":\\\"${tweet_info_reply.id_str}\\\",\\\"reported_user_id\\\":\\\"${tweet_info_reply.user.id_str}\\\",\\\"source\\\":\\\"reporttweet\\\"}\",\"flow_context\":{\"debug_overrides\":{},\"start_location\":{\"location\":\"tweet\",\"tweet\":{\"tweet_id\":\"${tweet_info_reply.id_str}\"}}}},\"subtask_versions\":{\"action_list\":2,\"alert_dialog\":1,\"app_download_cta\":1,\"check_logged_in_account\":1,\"choice_selection\":3,\"contacts_live_sync_permission_prompt\":0,\"cta\":7,\"email_verification\":2,\"end_flow\":1,\"enter_date\":1,\"enter_email\":2,\"enter_password\":5,\"enter_phone\":2,\"enter_recaptcha\":1,\"enter_text\":5,\"enter_username\":2,\"generic_urt\":3,\"in_app_notification\":1,\"interest_picker\":3,\"js_instrumentation\":1,\"menu_dialog\":1,\"notifications_permission_prompt\":2,\"open_account\":2,\"open_home_timeline\":1,\"open_link\":1,\"phone_verification\":4,\"privacy_options\":1,\"security_key\":3,\"select_avatar\":4,\"select_banner\":2,\"settings_list\":7,\"show_code\":1,\"sign_up\":2,\"sign_up_review\":4,\"tweet_selection_urt\":1,\"update_users\":1,\"upload_media\":1,\"user_recommendations_list\":4,\"user_recommendations_urt\":1,\"wait_spinner\":3,\"web_modal\":1}}`;
+                            const user_report_json_body = `{\"input_flow_data\":{\"requested_variant\":\"{\\\"client_app_id\\\":\\\"3033300\\\",\\\"client_location\\\":\\\"profile:header:\\\",\\\"client_referer\\\":\\\"/${tweet_info_reply.user.screen_name}\\\",\\\"is_media\\\":false,\\\"is_promoted\\\":false,\\\"report_flow_id\\\":\\\"%cslt_random_uuid%\\\",\\\"reported_user_id\\\":\\\"${tweet_info_reply.user.id_str}\\\",\\\"source\\\":\\\"reportprofile\\\"}\",\"flow_context\":{\"debug_overrides\":{},\"start_location\":{\"location\":\"profile\",\"profile\":{\"profile_id\":\"${tweet_info_reply.user.id_str}\"}}}}}`;
+                            //ツイート情報オブジェクト生成
+                            let is_reply_root_tweet = false;
+                            let reply_quoted_obj = null;
+                            let reply_out_urls = null;
+                            let quoted_urls = null;
+                            let is_reply_status = false;
+                            let reply_user_data_status_obj = null;
+                            let reply_twitter_card_obj = null;
+                            let reply_twitter_card_unified_obj = null;
+                            let reply_blocked_by_flag = false;
+                            let reply_quoted_blocked_by_flag = false;
+                            if(tweet_info_reply.permalink == location.pathname){
+                                is_reply_root_tweet = true;
                             }
-                            if(tweet_info_reply.quoted_status.user.blocked_by){
-                                reply_quoted_blocked_by_flag = true;
-                            }
-                            reply_quoted_obj = {
-                                text:tweet_info_reply.quoted_status.full_text,
-                                mentions: tweet_info_reply.quoted_status.entities?.user_mentions ?? null,
-                                possibly_sensitive:tweet_info_reply.quoted_status.possibly_sensitive,
-                                possibly_sensitive_editable:tweet_info_reply.quoted_status.possibly_sensitive_editable,
-                                "quoted_urls":quoted_urls,
-                                tweet_lang: tweet_info_reply.quoted_status.lang,
-                                content_disclosure: tweet_info_reply.quoted_status?.content_disclosure ?? null,
-                                user_data:{
-                                    name: tweet_info_reply.quoted_status.user.name, 
-                                    description: tweet_info_reply.quoted_status.user.description,
-                                    user_id: tweet_info_reply.quoted_status.user.id_str,
-                                    scr_name: tweet_info_reply.quoted_status.user.screen_name,
-                                    all_tweet_count: tweet_info_reply.quoted_status.user.statuses_count,
-                                    is_blue:tweet_info_reply.quoted_status.user.is_blue_verified,
-                                    location: tweet_info_reply.quoted_status.user.location,
-                                    account_create_date: tweet_info_reply.quoted_status.user.created_at,
-                                    blocked_by: reply_quoted_blocked_by_flag
+                            if(tweet_info_reply.quoted_status != undefined){
+                                if(tweet_info_reply.quoted_status?.entities?.urls?.length != 0){
+                                    quoted_urls = tweet_info_reply.quoted_status.entities.urls;
+                                }
+                                if(tweet_info_reply.quoted_status.user.blocked_by){
+                                    reply_quoted_blocked_by_flag = true;
+                                }
+                                reply_quoted_obj = {
+                                    text:tweet_info_reply.quoted_status.full_text,
+                                    mentions: tweet_info_reply.quoted_status.entities?.user_mentions ?? null,
+                                    possibly_sensitive:tweet_info_reply.quoted_status.possibly_sensitive,
+                                    possibly_sensitive_editable:tweet_info_reply.quoted_status.possibly_sensitive_editable,
+                                    "quoted_urls":quoted_urls,
+                                    tweet_lang: tweet_info_reply.quoted_status.lang,
+                                    content_disclosure: tweet_info_reply.quoted_status?.content_disclosure ?? null,
+                                    user_data:{
+                                        name: tweet_info_reply.quoted_status.user.name, 
+                                        description: tweet_info_reply.quoted_status.user.description,
+                                        user_id: tweet_info_reply.quoted_status.user.id_str,
+                                        scr_name: tweet_info_reply.quoted_status.user.screen_name,
+                                        all_tweet_count: tweet_info_reply.quoted_status.user.statuses_count,
+                                        is_blue:tweet_info_reply.quoted_status.user.is_blue_verified,
+                                        location: tweet_info_reply.quoted_status.user.location,
+                                        account_create_date: tweet_info_reply.quoted_status.user.created_at,
+                                        blocked_by: reply_quoted_blocked_by_flag
+                                    }
                                 }
                             }
-                        }
-                        if(tweet_info_reply.entities?.urls?.length != 0){
-                            reply_out_urls = tweet_info_reply.entities.urls;
-                        }
-                        if(tweet_info_reply.in_reply_to_status_id_str != undefined){
-                            is_reply_status = true;
-                            reply_user_data_status_obj = {
-                                name: tweet_info_reply.in_reply_to_user.name, 
-                                user_id: tweet_info_reply.in_reply_to_user.id_str,
-                                scr_name: tweet_info_reply.in_reply_to_user.screen_name,
-                                all_tweet_count: tweet_info_reply.in_reply_to_user.statuses_count,
-                                is_blue:tweet_info_reply.in_reply_to_user.is_blue_verified,
-                                location: tweet_info_reply.in_reply_to_user.location,
-                                account_create_date: tweet_info_reply.in_reply_to_user.created_at
+                            if(tweet_info_reply.entities?.urls?.length != 0){
+                                reply_out_urls = tweet_info_reply.entities.urls;
                             }
-                        }
-                        if(tweet_info_reply?.card?.binding_values?.domain?.string_value != undefined){
-                            reply_twitter_card_obj = {
-                                domain: tweet_info_reply.card.binding_values.domain.string_value
+                            if(tweet_info_reply.in_reply_to_status_id_str != undefined){
+                                is_reply_status = true;
+                                reply_user_data_status_obj = {
+                                    name: tweet_info_reply.in_reply_to_user.name, 
+                                    user_id: tweet_info_reply.in_reply_to_user.id_str,
+                                    scr_name: tweet_info_reply.in_reply_to_user.screen_name,
+                                    all_tweet_count: tweet_info_reply.in_reply_to_user.statuses_count,
+                                    is_blue:tweet_info_reply.in_reply_to_user.is_blue_verified,
+                                    location: tweet_info_reply.in_reply_to_user.location,
+                                    account_create_date: tweet_info_reply.in_reply_to_user.created_at
+                                }
                             }
-                        }
-                        if(tweet_info_reply?.card?.binding_values?.unified_card?.string_value){
-                            reply_twitter_card_unified_obj = JSON.parse(tweet_info_reply?.card?.binding_values?.unified_card?.string_value)
-                        }
-                        if(tweet_info_reply.user.blocked_by){
-                            reply_blocked_by_flag = true;
-                        }
-                        const tweetinfo_attr_reply = {
-                            is_root_tweet: is_reply_root_tweet,
-                            mentions: tweet_info_reply.entities?.user_mentions ?? null,
-                            text: tweet_info_reply.text,
-                            tweet_id: tweet_info_reply.id_str, 
-                            tweet_client: tweet_info_reply.source_name,
-                            is_reply: is_reply_status,
-                            is_user_data_only: false,
-                            tweet_lang: tweet_info_reply.lang,
-                            is_promoted: is_promo_tweet,
-                            grok_share_attachment: tweet_info_reply?.grok_share_attachment ?? null,
-                            content_disclosure: tweet_info_reply?.content_disclosure ?? null,
-                            user_data:{
-                                name: tweet_info_reply.user.name, 
-                                description: tweet_info_reply.user.description,
-                                user_id: tweet_info_reply.user.id_str,
-                                scr_name: tweet_info_reply.user.screen_name,
-                                all_tweet_count: tweet_info_reply.user.statuses_count,
-                                is_blue: tweet_info_reply.user.is_blue_verified,
-                                location: tweet_info_reply.user.location,
-                                account_create_date: tweet_info_reply.user.created_at,
-                                blocked_by: reply_blocked_by_flag
-                            },
-                            in_reply_user_data: reply_user_data_status_obj,
-                            tweet_video_info: video_info,
-                            report_json: report_json_body,
-                            user_report_json:user_report_json_body,
-                            "quoted_obj":reply_quoted_obj,
-                            "attached_urls":reply_out_urls,
-                            "tw_card_unified_obj": reply_twitter_card_unified_obj,
-                            "tw_card_obj": reply_twitter_card_obj
-                        };
-                        //console.log(tweetinfo_attr_reply)
-                        const target_root_elem_reply = tweet_elem[tweet_index].closest('[data-testid="cellInnerDiv"]');
-                        target_root_elem_reply.setAttribute("cslt_tweet_info", JSON.stringify(tweetinfo_attr_reply));
-                        //フォロー済フラグ付加
-                        if(tweet_info_reply.user.following){
-                            target_root_elem_reply.setAttribute("cslt_tweet_info_following_flag", "true");
-                        }
-                        //自分のツイートフラグ付加
-                        if(login_userid() == tweet_info_reply.user.screen_name){
-                            target_root_elem_reply.setAttribute("cslt_tweet_info_mytweet_flag", "true");
-                        }
-                        //Blue認証付きフラグ
-                        if(tweet_info_reply.user.is_blue_verified){
-                            target_root_elem_reply.setAttribute("cslt_tweet_info_isblue_flag", "true");
-                        }
-                    }
-                    break;
-                case 'followers':
-                    //button __reactProps$3d2jw1jzxv2.children[0][1].props.children[1].props.children[1].props.userId
-                    const view_user = window.location.pathname.split("/")[1];
-                    const now_follow_mode = window.location.pathname.split("/")[2];
-                    //console.log("follws_run")
-                    if(login_userid() == view_user && now_follow_mode == "followers"){
-                        const tweet_info_follow = get_tw_userdata(tweet_elem[tweet_index], "user_page");
-                        //console.log(tweet_info_follow)
-                        if(tweet_info_follow != undefined){
-                            //報告用JSON生成
-                            const report_json_body = `{\"input_flow_data\":{\"requested_variant\":\"{\\\"client_app_id\\\":\\\"3033300\\\",\\\"client_location\\\":\\\"profile:header:\\\",\\\"client_referer\\\":\\\"/${tweet_info_follow.screen_name}\\\",\\\"is_media\\\":false,\\\"is_promoted\\\":false,\\\"report_flow_id\\\":\\\"%cslt_random_uuid%\\\",\\\"reported_user_id\\\":\\\"${tweet_info_follow.id_str}\\\",\\\"source\\\":\\\"reportprofile\\\"}\",\"flow_context\":{\"debug_overrides\":{},\"start_location\":{\"location\":\"profile\",\"profile\":{\"profile_id\":\"${tweet_info_follow.id_str}\"}}}}}`;
-                            //ツイート情報オブジェクト生成
-                            const tweetinfo_attr_follow = {
-                                is_reply: false,
-                                is_user_data_only: true,
+                            if(tweet_info_reply?.card?.binding_values?.domain?.string_value != undefined){
+                                reply_twitter_card_obj = {
+                                    domain: tweet_info_reply.card.binding_values.domain.string_value
+                                }
+                            }
+                            if(tweet_info_reply?.card?.binding_values?.unified_card?.string_value){
+                                reply_twitter_card_unified_obj = JSON.parse(tweet_info_reply?.card?.binding_values?.unified_card?.string_value)
+                            }
+                            if(tweet_info_reply.user.blocked_by){
+                                reply_blocked_by_flag = true;
+                            }
+                            const tweetinfo_attr_reply = {
+                                is_root_tweet: is_reply_root_tweet,
+                                mentions: tweet_info_reply.entities?.user_mentions ?? null,
+                                text: tweet_info_reply.text,
+                                tweet_id: tweet_info_reply.id_str, 
+                                tweet_client: tweet_info_reply.source_name,
+                                is_reply: is_reply_status,
+                                is_user_data_only: false,
+                                tweet_lang: tweet_info_reply.lang,
+                                is_promoted: is_promo_tweet,
+                                grok_share_attachment: tweet_info_reply?.grok_share_attachment ?? null,
+                                content_disclosure: tweet_info_reply?.content_disclosure ?? null,
                                 user_data:{
-                                    name: tweet_info_follow.name, 
-                                    user_id: tweet_info_follow.id_str,
-                                    scr_name: tweet_info_follow.screen_name,
-                                    all_tweet_count: tweet_info_follow.statuses_count,
-                                    is_blue: tweet_info_follow.is_blue_verified
+                                    name: tweet_info_reply.user.name, 
+                                    description: tweet_info_reply.user.description,
+                                    user_id: tweet_info_reply.user.id_str,
+                                    scr_name: tweet_info_reply.user.screen_name,
+                                    all_tweet_count: tweet_info_reply.user.statuses_count,
+                                    is_blue: tweet_info_reply.user.is_blue_verified,
+                                    location: tweet_info_reply.user.location,
+                                    account_create_date: tweet_info_reply.user.created_at,
+                                    blocked_by: reply_blocked_by_flag
+                                },
+                                in_reply_user_data: reply_user_data_status_obj,
+                                tweet_video_info: video_info,
+                                report_json: report_json_body,
+                                user_report_json:user_report_json_body,
+                                "quoted_obj":reply_quoted_obj,
+                                "attached_urls":reply_out_urls,
+                                "tw_card_unified_obj": reply_twitter_card_unified_obj,
+                                "tw_card_obj": reply_twitter_card_obj
+                            };
+                            //console.log(tweetinfo_attr_reply)
+                            const target_root_elem_reply = tweet_elem[tweet_index].closest('[data-testid="cellInnerDiv"]');
+                            target_root_elem_reply.setAttribute("cslt_tweet_info", JSON.stringify(tweetinfo_attr_reply));
+                            //フォロー済フラグ付加
+                            if(tweet_info_reply.user.following){
+                                target_root_elem_reply.setAttribute("cslt_tweet_info_following_flag", "true");
+                            }
+                            //自分のツイートフラグ付加
+                            if(login_userid() == tweet_info_reply.user.screen_name){
+                                target_root_elem_reply.setAttribute("cslt_tweet_info_mytweet_flag", "true");
+                            }
+                            //Blue認証付きフラグ
+                            if(tweet_info_reply.user.is_blue_verified){
+                                target_root_elem_reply.setAttribute("cslt_tweet_info_isblue_flag", "true");
+                            }
+                        }
+                        break;
+                    case 'followers':
+                        //button __reactProps$3d2jw1jzxv2.children[0][1].props.children[1].props.children[1].props.userId
+                        const view_user = window.location.pathname.split("/")[1];
+                        const now_follow_mode = window.location.pathname.split("/")[2];
+                        //console.log("follws_run")
+                        if(login_userid() == view_user && now_follow_mode == "followers"){
+                            const tweet_info_follow = get_tw_userdata(tweet_elem[tweet_index], "user_page");
+                            //console.log(tweet_info_follow)
+                            if(tweet_info_follow != undefined){
+                                //報告用JSON生成
+                                const report_json_body = `{\"input_flow_data\":{\"requested_variant\":\"{\\\"client_app_id\\\":\\\"3033300\\\",\\\"client_location\\\":\\\"profile:header:\\\",\\\"client_referer\\\":\\\"/${tweet_info_follow.screen_name}\\\",\\\"is_media\\\":false,\\\"is_promoted\\\":false,\\\"report_flow_id\\\":\\\"%cslt_random_uuid%\\\",\\\"reported_user_id\\\":\\\"${tweet_info_follow.id_str}\\\",\\\"source\\\":\\\"reportprofile\\\"}\",\"flow_context\":{\"debug_overrides\":{},\"start_location\":{\"location\":\"profile\",\"profile\":{\"profile_id\":\"${tweet_info_follow.id_str}\"}}}}}`;
+                                //ツイート情報オブジェクト生成
+                                const tweetinfo_attr_follow = {
+                                    is_reply: false,
+                                    is_user_data_only: true,
+                                    user_data:{
+                                        name: tweet_info_follow.name, 
+                                        user_id: tweet_info_follow.id_str,
+                                        scr_name: tweet_info_follow.screen_name,
+                                        all_tweet_count: tweet_info_follow.statuses_count,
+                                        is_blue: tweet_info_follow.is_blue_verified
+                                    },
+                                    report_json: null,
+                                    user_report_json:report_json_body
+                                };
+                                //console.log(tweet_info_follow);
+                                //console.log(tweetinfo_attr_follow)
+                                tweet_elem[tweet_index].closest('[data-testid="cellInnerDiv"]').setAttribute("cslt_tweet_info", JSON.stringify(tweetinfo_attr_follow));
+                            }
+                        }else{
+                            const tweet_info_follow = get_tw_userdata(tweet_elem[tweet_index], "user_page_ids");
+                            //console.log(tweet_info_follow)
+                            const report_json_body = `{\"input_flow_data\":{\"requested_variant\":\"{\\\"client_app_id\\\":\\\"3033300\\\",\\\"client_location\\\":\\\"profile:header:\\\",\\\"client_referer\\\":\\\"/${tweet_info_follow.screen_name}\\\",\\\"is_media\\\":false,\\\"is_promoted\\\":false,\\\"report_flow_id\\\":\\\"%cslt_random_uuid%\\\",\\\"reported_user_id\\\":\\\"${tweet_info_follow.userId}\\\",\\\"source\\\":\\\"reportprofile\\\"}\",\"flow_context\":{\"debug_overrides\":{},\"start_location\":{\"location\":\"profile\",\"profile\":{\"profile_id\":\"${tweet_info_follow.userId}\"}}}}}`;
+                            const tweetinfo_attr_follow = {
+                                user_data:{
+                                    user_id: tweet_info_follow.userId,
+                                    scr_name: tweet_info_follow.screen_name
                                 },
                                 report_json: null,
-                                user_report_json:report_json_body
+                                user_report_json: report_json_body,
+                                is_user_data_only: true,
+                                is_reply: false
                             };
                             //console.log(tweet_info_follow);
                             //console.log(tweetinfo_attr_follow)
                             tweet_elem[tweet_index].closest('[data-testid="cellInnerDiv"]').setAttribute("cslt_tweet_info", JSON.stringify(tweetinfo_attr_follow));
                         }
-                    }else{
-                        const tweet_info_follow = get_tw_userdata(tweet_elem[tweet_index], "user_page_ids");
-                        //console.log(tweet_info_follow)
-                        const report_json_body = `{\"input_flow_data\":{\"requested_variant\":\"{\\\"client_app_id\\\":\\\"3033300\\\",\\\"client_location\\\":\\\"profile:header:\\\",\\\"client_referer\\\":\\\"/${tweet_info_follow.screen_name}\\\",\\\"is_media\\\":false,\\\"is_promoted\\\":false,\\\"report_flow_id\\\":\\\"%cslt_random_uuid%\\\",\\\"reported_user_id\\\":\\\"${tweet_info_follow.userId}\\\",\\\"source\\\":\\\"reportprofile\\\"}\",\"flow_context\":{\"debug_overrides\":{},\"start_location\":{\"location\":\"profile\",\"profile\":{\"profile_id\":\"${tweet_info_follow.userId}\"}}}}}`;
-                        const tweetinfo_attr_follow = {
-                            user_data:{
-                                user_id: tweet_info_follow.userId,
-                                scr_name: tweet_info_follow.screen_name
-                            },
-                            report_json: null,
-                            user_report_json: report_json_body,
-                            is_user_data_only: true,
-                            is_reply: false
-                        };
-                        //console.log(tweet_info_follow);
-                        //console.log(tweetinfo_attr_follow)
-                        tweet_elem[tweet_index].closest('[data-testid="cellInnerDiv"]').setAttribute("cslt_tweet_info", JSON.stringify(tweetinfo_attr_follow));
-                    }
-                case 'other':
-                    //console.log(window.location.pathname.split("/")[2])
-                    //console.log("other")
-                    //通知ページの場合(仮実装)
-                    if(tweet_elem[tweet_index].getAttribute("data-testid") == 'notification'){
-                        const notification_user_info = get_tw_userdata(tweet_elem[tweet_index], "notification_like_rt");
-                        const notification_user_data_array = [];
-                        //console.log(notification_user_info)
-                        if(notification_user_info != undefined){
-                            for (let notification_user_index = 0; notification_user_index < notification_user_info.length; notification_user_index++) {
-                                const notification_user_data = notification_user_info[notification_user_index];
-                                const report_json_body_notification = `{\"input_flow_data\":{\"requested_variant\":\"{\\\"client_app_id\\\":\\\"3033300\\\",\\\"client_location\\\":\\\"profile:header:\\\",\\\"client_referer\\\":\\\"/${notification_user_data.screen_name}\\\",\\\"is_media\\\":false,\\\"is_promoted\\\":false,\\\"report_flow_id\\\":\\\"%cslt_random_uuid%\\\",\\\"reported_user_id\\\":\\\"${notification_user_data.id_str}\\\",\\\"source\\\":\\\"reportprofile\\\"}\",\"flow_context\":{\"debug_overrides\":{},\"start_location\":{\"location\":\"profile\",\"profile\":{\"profile_id\":\"${notification_user_data.id_str}\"}}}}}`;
-                                notification_user_data_array.push(
-                                    {
-                                        is_user_data_only: true,
-                                        is_reply: false,
-                                        user_data:{name: notification_user_data.name, description: notification_user_data.description, user_id: notification_user_data.id_str, scr_name: notification_user_data.screen_name, all_tweet_count: notification_user_data.statuses_count, is_blue: notification_user_data.is_blue_verified, location: notification_user_data.location, account_create_date: notification_user_data.created_at, blocked_by: null},
+                    case 'other':
+                        //console.log(window.location.pathname.split("/")[2])
+                        //console.log("other")
+                        //通知ページの場合(仮実装)
+                        if(tweet_elem[tweet_index].getAttribute("data-testid") == 'notification'){
+                            const notification_user_info = get_tw_userdata(tweet_elem[tweet_index], "notification_like_rt");
+                            const notification_user_data_array = [];
+                            //console.log(notification_user_info)
+                            if(notification_user_info != undefined){
+                                for (let notification_user_index = 0; notification_user_index < notification_user_info.length; notification_user_index++) {
+                                    const notification_user_data = notification_user_info[notification_user_index];
+                                    const report_json_body_notification = `{\"input_flow_data\":{\"requested_variant\":\"{\\\"client_app_id\\\":\\\"3033300\\\",\\\"client_location\\\":\\\"profile:header:\\\",\\\"client_referer\\\":\\\"/${notification_user_data.screen_name}\\\",\\\"is_media\\\":false,\\\"is_promoted\\\":false,\\\"report_flow_id\\\":\\\"%cslt_random_uuid%\\\",\\\"reported_user_id\\\":\\\"${notification_user_data.id_str}\\\",\\\"source\\\":\\\"reportprofile\\\"}\",\"flow_context\":{\"debug_overrides\":{},\"start_location\":{\"location\":\"profile\",\"profile\":{\"profile_id\":\"${notification_user_data.id_str}\"}}}}}`;
+                                    notification_user_data_array.push(
+                                        {
+                                            is_user_data_only: true,
+                                            is_reply: false,
+                                            user_data:{name: notification_user_data.name, description: notification_user_data.description, user_id: notification_user_data.id_str, scr_name: notification_user_data.screen_name, all_tweet_count: notification_user_data.statuses_count, is_blue: notification_user_data.is_blue_verified, location: notification_user_data.location, account_create_date: notification_user_data.created_at, blocked_by: null},
+                                            report_json: null,
+                                            user_report_json: report_json_body_notification
+                                        }
+                                    );
+                                }
+                                const notification_user_obj = {
+                                    user_data_array: notification_user_data_array
+                                }
+                                const target_root_elem_notification = tweet_elem[tweet_index].closest('[data-testid="cellInnerDiv"]');
+                                target_root_elem_notification.setAttribute("cslt_notifications_page_element", "");
+                                target_root_elem_notification.setAttribute("cslt_tweet_info", JSON.stringify(notification_user_obj));//cslt_notification_users_info
+                            }
+                        }
+                        //ユーザーページの場合
+                        const user_page_header_item = document.querySelector('div[data-testid="UserName"]:not([cslt_user_page_info_element])');
+                        if(user_page_header_item != null){
+                            const user_page_info = get_tw_userdata(user_page_header_item, "user_page_info");
+                            //console.log(user_page_info)
+                            const report_json_body_user_page = `{\"input_flow_data\":{\"requested_variant\":\"{\\\"client_app_id\\\":\\\"3033300\\\",\\\"client_location\\\":\\\"profile:header:\\\",\\\"client_referer\\\":\\\"/${user_page_info.screen_name}\\\",\\\"is_media\\\":false,\\\"is_promoted\\\":false,\\\"report_flow_id\\\":\\\"%cslt_random_uuid%\\\",\\\"reported_user_id\\\":\\\"${user_page_info.id_str}\\\",\\\"source\\\":\\\"reportprofile\\\"}\",\"flow_context\":{\"debug_overrides\":{},\"start_location\":{\"location\":\"profile\",\"profile\":{\"profile_id\":\"${user_page_info.id_str}\"}}}}}`;
+                                const userinfo_attr = {
+                                    user_data_array:[
+                                        {
+                                            user_data:{
+                                            name: user_page_info?.name, 
+                                            user_id: user_page_info?.id_str,
+                                            scr_name: user_page_info?.screen_name,
+                                            all_tweet_count: user_page_info?.statuses_count,
+                                            is_blue: user_page_info?.is_blue_verified
+                                        },
                                         report_json: null,
-                                        user_report_json: report_json_body_notification
+                                        user_report_json: report_json_body_user_page,
+                                        is_user_data_only: true,
+                                        is_reply: false
                                     }
-                                );
-                            }
-                            const notification_user_obj = {
-                                user_data_array: notification_user_data_array
-                            }
-                            const target_root_elem_notification = tweet_elem[tweet_index].closest('[data-testid="cellInnerDiv"]');
-                            target_root_elem_notification.setAttribute("cslt_notifications_page_element", "");
-                            target_root_elem_notification.setAttribute("cslt_tweet_info", JSON.stringify(notification_user_obj));//cslt_notification_users_info
+                                ]
+                            };
+                            //console.log(userinfo_attr);
+                            user_page_header_item.setAttribute("cslt_tweet_info", JSON.stringify(userinfo_attr));
+                            user_page_header_item.setAttribute("cslt_user_page_user_scr_name", user_page_info?.screen_name);
+                            user_page_header_item.setAttribute("cslt_user_page_info_element", "");
                         }
-                    }
-                    //ユーザーページの場合
-                    const user_page_header_item = document.querySelector('div[data-testid="UserName"]:not([cslt_user_page_info_element])');
-                    if(user_page_header_item != null){
-                        const user_page_info = get_tw_userdata(user_page_header_item, "user_page_info");
-                        //console.log(user_page_info)
-                        const report_json_body_user_page = `{\"input_flow_data\":{\"requested_variant\":\"{\\\"client_app_id\\\":\\\"3033300\\\",\\\"client_location\\\":\\\"profile:header:\\\",\\\"client_referer\\\":\\\"/${user_page_info.screen_name}\\\",\\\"is_media\\\":false,\\\"is_promoted\\\":false,\\\"report_flow_id\\\":\\\"%cslt_random_uuid%\\\",\\\"reported_user_id\\\":\\\"${user_page_info.id_str}\\\",\\\"source\\\":\\\"reportprofile\\\"}\",\"flow_context\":{\"debug_overrides\":{},\"start_location\":{\"location\":\"profile\",\"profile\":{\"profile_id\":\"${user_page_info.id_str}\"}}}}}`;
-                            const userinfo_attr = {
-                                user_data_array:[
-                                    {
-                                        user_data:{
-                                        name: user_page_info?.name, 
-                                        user_id: user_page_info?.id_str,
-                                        scr_name: user_page_info?.screen_name,
-                                        all_tweet_count: user_page_info?.statuses_count,
-                                        is_blue: user_page_info?.is_blue_verified
-                                    },
-                                    report_json: null,
-                                    user_report_json: report_json_body_user_page,
-                                    is_user_data_only: true,
-                                    is_reply: false
-                                }
-                            ]
-                        };
-                        //console.log(userinfo_attr);
-                        user_page_header_item.setAttribute("cslt_tweet_info", JSON.stringify(userinfo_attr));
-                        user_page_header_item.setAttribute("cslt_user_page_user_scr_name", user_page_info?.screen_name);
-                        user_page_header_item.setAttribute("cslt_user_page_info_element", "");
-                    }
-                    //
-                    const tweet_info_other = get_tw_userdata(tweet_elem[tweet_index], "reply");
+                        //
+                        const tweet_info_other = get_tw_userdata(tweet_elem[tweet_index], "reply");
 
-                    //console.dir(tweet_info_other)
+                        //console.dir(tweet_info_other)
 
-                    if(tweet_info_other != undefined){
-                        //報告用JSON生成
-                        let is_media_tweet = false;
-                        let is_promo_tweet = false;
-                        if(tweet_info_other.extended_entities?.media[0] != undefined){
-                            is_media_tweet = true;
-                        }
-                        if(tweet_info_other.promoted_content != undefined){
-                            is_promo_tweet = true;
-                        }
-                        //動画情報取り出し
-                        if(is_media_tweet){
-                            const media_info_obj = tweet_info_other.entities?.media;
-                            //console.log(media_info_obj)
-                            for (let index = 0; index < media_info_obj.length; index++) {
-                                if(media_info_obj[index].type == "video"){
-                                    //console.log(media_info_obj[index])
-                                    let media_source_user_data = null;
-                                    if(media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy != undefined){
-                                        media_source_user_data = {
-                                            user_data:{
-                                                name: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.name, 
-                                                description: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.description,
-                                                user_id: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.id_str,
-                                                scr_name: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.screen_name,
-                                                all_tweet_count: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.statuses_count,
-                                                is_blue:media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.is_blue_verified,
-                                                location: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.location,
-                                                account_create_date: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.created_at
+                        if(tweet_info_other != undefined){
+                            //報告用JSON生成
+                            let is_media_tweet = false;
+                            let is_promo_tweet = false;
+                            if(tweet_info_other.extended_entities?.media[0] != undefined){
+                                is_media_tweet = true;
+                            }
+                            if(tweet_info_other.promoted_content != undefined){
+                                is_promo_tweet = true;
+                            }
+                            //動画情報取り出し
+                            if(is_media_tweet){
+                                const media_info_obj = tweet_info_other.entities?.media;
+                                //console.log(media_info_obj)
+                                for (let index = 0; index < media_info_obj.length; index++) {
+                                    if(media_info_obj[index].type == "video"){
+                                        //console.log(media_info_obj[index])
+                                        let media_source_user_data = null;
+                                        if(media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy != undefined){
+                                            media_source_user_data = {
+                                                user_data:{
+                                                    name: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.name, 
+                                                    description: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.description,
+                                                    user_id: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.id_str,
+                                                    scr_name: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.screen_name,
+                                                    all_tweet_count: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.statuses_count,
+                                                    is_blue:media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.is_blue_verified,
+                                                    location: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.location,
+                                                    account_create_date: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.created_at
+                                                }
                                             }
                                         }
+                                        const media_info = {
+                                            type: media_info_obj[index].type,
+                                            duration_ms: media_info_obj[index].video_info.duration_millis,
+                                            video_raw: media_info_obj[index].video_info.variants.at(-1),
+                                            video_source_user_info:media_source_user_data
+                                        }
+                                        video_info.push(media_info);
                                     }
-                                    const media_info = {
-                                        type: media_info_obj[index].type,
-                                        duration_ms: media_info_obj[index].video_info.duration_millis,
-                                        video_raw: media_info_obj[index].video_info.variants.at(-1),
-                                        video_source_user_info:media_source_user_data
+                                    if(media_info_obj[index].type == "animated_gif"){
+                                        const media_info = {
+                                            type: media_info_obj[index].type,
+                                            duration_ms: null,
+                                            video_raw: media_info_obj[index].video_info.variants.at(-1),
+                                            video_source_user_info: null
+                                        }
+                                        video_info.push(media_info);
                                     }
-                                    video_info.push(media_info);
                                 }
-                                if(media_info_obj[index].type == "animated_gif"){
-                                    const media_info = {
-                                        type: media_info_obj[index].type,
-                                        duration_ms: null,
-                                        video_raw: media_info_obj[index].video_info.variants.at(-1),
-                                        video_source_user_info: null
-                                    }
-                                    video_info.push(media_info);
+                                if(video_info.length == 0){
+                                    video_info = null;
                                 }
-                            }
-                            if(video_info.length == 0){
+                            }else{
                                 video_info = null;
                             }
-                        }else{
-                            video_info = null;
-                        }
-                        //ツイート情報オブジェクト生成
-                        const report_json_body = `{\"input_flow_data\":{\"requested_variant\":\"{\\\"client_app_id\\\":\\\"3033300\\\",\\\"client_location\\\":\\\"tweet:conversation_descendants:tweet\\\",\\\"client_referer\\\":\\\"${tweet_info_other.permalink}\\\",\\\"is_media\\\":${is_media_tweet},\\\"is_promoted\\\":${is_promo_tweet},\\\"report_flow_id\\\":\\\"%cslt_random_uuid%\\\",\\\"reported_tweet_id\\\":\\\"${tweet_info_other.id_str}\\\",\\\"reported_user_id\\\":\\\"${tweet_info_other.user.id_str}\\\",\\\"source\\\":\\\"reporttweet\\\"}\",\"flow_context\":{\"debug_overrides\":{},\"start_location\":{\"location\":\"tweet\",\"tweet\":{\"tweet_id\":\"${tweet_info_other.id_str}\"}}}}}`;
-                        const user_report_json_body = `{\"input_flow_data\":{\"requested_variant\":\"{\\\"client_app_id\\\":\\\"3033300\\\",\\\"client_location\\\":\\\"profile:header:\\\",\\\"client_referer\\\":\\\"/${tweet_info_other.user.screen_name}\\\",\\\"is_media\\\":false,\\\"is_promoted\\\":false,\\\"report_flow_id\\\":\\\"%cslt_random_uuid%\\\",\\\"reported_user_id\\\":\\\"${tweet_info_other.user.id_str}\\\",\\\"source\\\":\\\"reportprofile\\\"}\",\"flow_context\":{\"debug_overrides\":{},\"start_location\":{\"location\":\"profile\",\"profile\":{\"profile_id\":\"${tweet_info_other.user.id_str}\"}}}}}`;
-                        let is_other_root_tweet = false;
-                        let is_reply_other = false;
-                        let reply_user_data_other_obj = null;
-                        let other_twitter_card_obj = null;
-                        let other_twitter_card_unified_obj = null;
-                        let other_out_urls = null;
-                        let other_blocked_by_flag = false;
-                        let other_quoted_obj = null;
-                        let other_quoted_urls = null;
-                        let other_quoted_blocked_by_flag = false;
-                        if(tweet_info_other?.permalink == location.pathname){
-                            is_other_root_tweet = true;
-                        }
-                        if(tweet_info_other?.in_reply_to_status_id_str != undefined){
-                            is_reply_other = true;
-                            reply_user_data_other_obj = {
-                                user_id: tweet_info_other?.in_reply_to_user.id_str,
-                                scr_name: tweet_info_other?.in_reply_to_user.screen_name
+                            //ツイート情報オブジェクト生成
+                            const report_json_body = `{\"input_flow_data\":{\"requested_variant\":\"{\\\"client_app_id\\\":\\\"3033300\\\",\\\"client_location\\\":\\\"tweet:conversation_descendants:tweet\\\",\\\"client_referer\\\":\\\"${tweet_info_other.permalink}\\\",\\\"is_media\\\":${is_media_tweet},\\\"is_promoted\\\":${is_promo_tweet},\\\"report_flow_id\\\":\\\"%cslt_random_uuid%\\\",\\\"reported_tweet_id\\\":\\\"${tweet_info_other.id_str}\\\",\\\"reported_user_id\\\":\\\"${tweet_info_other.user.id_str}\\\",\\\"source\\\":\\\"reporttweet\\\"}\",\"flow_context\":{\"debug_overrides\":{},\"start_location\":{\"location\":\"tweet\",\"tweet\":{\"tweet_id\":\"${tweet_info_other.id_str}\"}}}}}`;
+                            const user_report_json_body = `{\"input_flow_data\":{\"requested_variant\":\"{\\\"client_app_id\\\":\\\"3033300\\\",\\\"client_location\\\":\\\"profile:header:\\\",\\\"client_referer\\\":\\\"/${tweet_info_other.user.screen_name}\\\",\\\"is_media\\\":false,\\\"is_promoted\\\":false,\\\"report_flow_id\\\":\\\"%cslt_random_uuid%\\\",\\\"reported_user_id\\\":\\\"${tweet_info_other.user.id_str}\\\",\\\"source\\\":\\\"reportprofile\\\"}\",\"flow_context\":{\"debug_overrides\":{},\"start_location\":{\"location\":\"profile\",\"profile\":{\"profile_id\":\"${tweet_info_other.user.id_str}\"}}}}}`;
+                            let is_other_root_tweet = false;
+                            let is_reply_other = false;
+                            let reply_user_data_other_obj = null;
+                            let other_twitter_card_obj = null;
+                            let other_twitter_card_unified_obj = null;
+                            let other_out_urls = null;
+                            let other_blocked_by_flag = false;
+                            let other_quoted_obj = null;
+                            let other_quoted_urls = null;
+                            let other_quoted_blocked_by_flag = false;
+                            if(tweet_info_other?.permalink == location.pathname){
+                                is_other_root_tweet = true;
                             }
-                        }
-                        if(tweet_info_other?.card?.binding_values?.domain?.string_value != undefined){
-                            other_twitter_card_obj = {
-                                domain: tweet_info_other?.card.binding_values.domain.string_value
+                            if(tweet_info_other?.in_reply_to_status_id_str != undefined){
+                                is_reply_other = true;
+                                reply_user_data_other_obj = {
+                                    user_id: tweet_info_other?.in_reply_to_user.id_str,
+                                    scr_name: tweet_info_other?.in_reply_to_user.screen_name
+                                }
                             }
-                        }
-                        //twittercard動画付オブジェクト
-                        if(tweet_info_other?.card?.binding_values?.unified_card?.string_value){
-                            other_twitter_card_unified_obj = JSON.parse(tweet_info_other?.card?.binding_values?.unified_card?.string_value)
-                        }
-                        if(tweet_info_other?.entities?.urls?.length != 0){
-                            other_out_urls = tweet_info_other?.entities.urls;
-                        }
-                        if(tweet_info_other?.user.blocked_by){
-                            other_blocked_by_flag = true;
-                        }
-                        //引用オブジェクト
-                        if(tweet_info_other?.quoted_status != undefined){
-                            if(tweet_info_other?.quoted_status?.entities?.urls?.length != 0){
-                                other_quoted_urls = tweet_info_other?.quoted_status.entities.urls;
+                            if(tweet_info_other?.card?.binding_values?.domain?.string_value != undefined){
+                                other_twitter_card_obj = {
+                                    domain: tweet_info_other?.card.binding_values.domain.string_value
+                                }
                             }
-                            if(tweet_info_other?.quoted_status.user.blocked_by){
-                                other_quoted_blocked_by_flag = true;
+                            //twittercard動画付オブジェクト
+                            if(tweet_info_other?.card?.binding_values?.unified_card?.string_value){
+                                other_twitter_card_unified_obj = JSON.parse(tweet_info_other?.card?.binding_values?.unified_card?.string_value)
                             }
-                            other_quoted_obj = {
-                                text:tweet_info_other?.quoted_status.full_text,
-                                mentions: tweet_info_other?.quoted_status.entities?.user_mentions ?? null,
-                                possibly_sensitive:tweet_info_other?.quoted_status.possibly_sensitive,
-                                possibly_sensitive_editable:tweet_info_other?.quoted_status.possibly_sensitive_editable,
-                                "quoted_urls":other_quoted_urls,
-                                tweet_lang: tweet_info_other?.quoted_status.lang,
-                                content_disclosure: tweet_info_other?.quoted_status?.content_disclosure ?? null,
+                            if(tweet_info_other?.entities?.urls?.length != 0){
+                                other_out_urls = tweet_info_other?.entities.urls;
+                            }
+                            if(tweet_info_other?.user.blocked_by){
+                                other_blocked_by_flag = true;
+                            }
+                            //引用オブジェクト
+                            if(tweet_info_other?.quoted_status != undefined){
+                                if(tweet_info_other?.quoted_status?.entities?.urls?.length != 0){
+                                    other_quoted_urls = tweet_info_other?.quoted_status.entities.urls;
+                                }
+                                if(tweet_info_other?.quoted_status.user.blocked_by){
+                                    other_quoted_blocked_by_flag = true;
+                                }
+                                other_quoted_obj = {
+                                    text:tweet_info_other?.quoted_status.full_text,
+                                    mentions: tweet_info_other?.quoted_status.entities?.user_mentions ?? null,
+                                    possibly_sensitive:tweet_info_other?.quoted_status.possibly_sensitive,
+                                    possibly_sensitive_editable:tweet_info_other?.quoted_status.possibly_sensitive_editable,
+                                    "quoted_urls":other_quoted_urls,
+                                    tweet_lang: tweet_info_other?.quoted_status.lang,
+                                    content_disclosure: tweet_info_other?.quoted_status?.content_disclosure ?? null,
+                                    user_data:{
+                                        name: tweet_info_other?.quoted_status.user.name, 
+                                        description: tweet_info_other?.quoted_status.user.description,
+                                        user_id: tweet_info_other?.quoted_status.user.id_str,
+                                        scr_name: tweet_info_other?.quoted_status.user.screen_name,
+                                        all_tweet_count: tweet_info_other?.quoted_status.user.statuses_count,
+                                        is_blue:tweet_info_other?.quoted_status.user.is_blue_verified,
+                                        location: tweet_info_other?.quoted_status.user.location,
+                                        account_create_date: tweet_info_other?.quoted_status.user.created_at,
+                                        blocked_by: other_quoted_blocked_by_flag
+                                    }
+                                }
+                            }
+                            const tweetinfo_attr_other = {
+                                is_root_tweet: is_other_root_tweet,
+                                mentions: tweet_info_other?.entities?.user_mentions ?? null,
+                                text: tweet_info_other?.text,
+                                tweet_id: tweet_info_other?.id_str, 
+                                tweet_client: tweet_info_other?.source_name,
+                                is_reply: is_reply_other,
+                                is_user_data_only: false,
+                                tweet_lang: tweet_info_other?.lang,
+                                is_promoted: is_promo_tweet,
+                                grok_share_attachment: tweet_info_other?.grok_share_attachment ?? null,
+                                content_disclosure: tweet_info_other?.content_disclosure ?? null,
                                 user_data:{
-                                    name: tweet_info_other?.quoted_status.user.name, 
-                                    description: tweet_info_other?.quoted_status.user.description,
-                                    user_id: tweet_info_other?.quoted_status.user.id_str,
-                                    scr_name: tweet_info_other?.quoted_status.user.screen_name,
-                                    all_tweet_count: tweet_info_other?.quoted_status.user.statuses_count,
-                                    is_blue:tweet_info_other?.quoted_status.user.is_blue_verified,
-                                    location: tweet_info_other?.quoted_status.user.location,
-                                    account_create_date: tweet_info_other?.quoted_status.user.created_at,
-                                    blocked_by: other_quoted_blocked_by_flag
-                                }
+                                    name: tweet_info_other?.user.name, 
+                                    description: tweet_info_other?.user.description,
+                                    user_id: tweet_info_other?.user.id_str,
+                                    scr_name: tweet_info_other?.user.screen_name,
+                                    all_tweet_count: tweet_info_other?.user.statuses_count,
+                                    is_blue: tweet_info_other?.user.is_blue_verified,
+                                    location: tweet_info_other?.user.location,
+                                    account_create_date: tweet_info_other?.user.created_at,
+                                    blocked_by: other_blocked_by_flag
+                                },
+                                in_reply_user_data: reply_user_data_other_obj,
+                                tweet_video_info: video_info,
+                                report_json: report_json_body,
+                                user_report_json: user_report_json_body,
+                                "quoted_obj":other_quoted_obj,
+                                "tw_card_obj": other_twitter_card_obj,
+                                "tw_card_unified_obj": other_twitter_card_unified_obj,
+                                "attached_urls": other_out_urls,
+                            };
+                            const target_root_elem_other = tweet_elem[tweet_index].closest('[data-testid="cellInnerDiv"]');
+                            target_root_elem_other.setAttribute("cslt_tweet_info", JSON.stringify(tweetinfo_attr_other));
+                            //フォロー済フラグ付加
+                            if(tweet_info_other?.user.following){
+                                target_root_elem_other.setAttribute("cslt_tweet_info_following_flag", "true");
+                            }
+                            //自分のツイートフラグ付加
+                            if(login_userid() == tweet_info_other.user.screen_name){
+                                target_root_elem_other.setAttribute("cslt_tweet_info_mytweet_flag", "true");
+                            }
+                            //Blue認証付きフラグ
+                            if(tweet_info_other.user.is_blue_verified){
+                                target_root_elem_other.setAttribute("cslt_tweet_info_isblue_flag", "true");
                             }
                         }
-                        const tweetinfo_attr_other = {
-                            is_root_tweet: is_other_root_tweet,
-                            mentions: tweet_info_other?.entities?.user_mentions ?? null,
-                            text: tweet_info_other?.text,
-                            tweet_id: tweet_info_other?.id_str, 
-                            tweet_client: tweet_info_other?.source_name,
-                            is_reply: is_reply_other,
-                            is_user_data_only: false,
-                            tweet_lang: tweet_info_other?.lang,
-                            is_promoted: is_promo_tweet,
-                            grok_share_attachment: tweet_info_other?.grok_share_attachment ?? null,
-                            content_disclosure: tweet_info_other?.content_disclosure ?? null,
-                            user_data:{
-                                name: tweet_info_other?.user.name, 
-                                description: tweet_info_other?.user.description,
-                                user_id: tweet_info_other?.user.id_str,
-                                scr_name: tweet_info_other?.user.screen_name,
-                                all_tweet_count: tweet_info_other?.user.statuses_count,
-                                is_blue: tweet_info_other?.user.is_blue_verified,
-                                location: tweet_info_other?.user.location,
-                                account_create_date: tweet_info_other?.user.created_at,
-                                blocked_by: other_blocked_by_flag
-                            },
-                            in_reply_user_data: reply_user_data_other_obj,
-                            tweet_video_info: video_info,
-                            report_json: report_json_body,
-                            user_report_json: user_report_json_body,
-                            "quoted_obj":other_quoted_obj,
-                            "tw_card_obj": other_twitter_card_obj,
-                            "tw_card_unified_obj": other_twitter_card_unified_obj,
-                            "attached_urls": other_out_urls,
-                        };
-                        const target_root_elem_other = tweet_elem[tweet_index].closest('[data-testid="cellInnerDiv"]');
-                        target_root_elem_other.setAttribute("cslt_tweet_info", JSON.stringify(tweetinfo_attr_other));
-                        //フォロー済フラグ付加
-                        if(tweet_info_other?.user.following){
-                            target_root_elem_other.setAttribute("cslt_tweet_info_following_flag", "true");
-                        }
-                        //自分のツイートフラグ付加
-                        if(login_userid() == tweet_info_other.user.screen_name){
-                            target_root_elem_other.setAttribute("cslt_tweet_info_mytweet_flag", "true");
-                        }
-                        //Blue認証付きフラグ
-                        if(tweet_info_other.user.is_blue_verified){
-                            target_root_elem_other.setAttribute("cslt_tweet_info_isblue_flag", "true");
-                        }
-                    }
-                    break;
-                case 'communities':
-                    const tweet_info_communities = get_tw_userdata(tweet_elem[tweet_index], "reply");
-                    if(tweet_info_communities != undefined){
-                        //報告用JSON生成
-                        let is_media_tweet = false;
-                        let is_promo_tweet = false;
-                        if(tweet_info_communities.extended_entities?.media != undefined){
-                            is_media_tweet = true;
-                        }
-                        if(tweet_info_communities.promoted_content != undefined){
-                            is_promo_tweet = true;
-                        }
-                        //動画情報取り出し
-                        if(is_media_tweet){
-                            const media_info_obj = tweet_info_communities.entities?.media;
-                            //console.log(media_info_obj)
-                            for (let index = 0; index < media_info_obj.length; index++) {
-                                if(media_info_obj[index].type == "video"){
-                                    //console.log(media_info_obj[index])
-                                    let media_source_user_data = null;
-                                    if(media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy != undefined){
-                                        media_source_user_data = {
-                                            user_data:{
-                                                name: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.name, 
-                                                description: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.description,
-                                                user_id: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.id_str,
-                                                scr_name: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.screen_name,
-                                                all_tweet_count: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.statuses_count,
-                                                is_blue:media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.is_blue_verified,
-                                                location: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.location,
-                                                account_create_date: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.created_at
+                        break;
+                    case 'communities':
+                        const tweet_info_communities = get_tw_userdata(tweet_elem[tweet_index], "reply");
+                        if(tweet_info_communities != undefined){
+                            //報告用JSON生成
+                            let is_media_tweet = false;
+                            let is_promo_tweet = false;
+                            if(tweet_info_communities.extended_entities?.media != undefined){
+                                is_media_tweet = true;
+                            }
+                            if(tweet_info_communities.promoted_content != undefined){
+                                is_promo_tweet = true;
+                            }
+                            //動画情報取り出し
+                            if(is_media_tweet){
+                                const media_info_obj = tweet_info_communities.entities?.media;
+                                //console.log(media_info_obj)
+                                for (let index = 0; index < media_info_obj.length; index++) {
+                                    if(media_info_obj[index].type == "video"){
+                                        //console.log(media_info_obj[index])
+                                        let media_source_user_data = null;
+                                        if(media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy != undefined){
+                                            media_source_user_data = {
+                                                user_data:{
+                                                    name: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.name, 
+                                                    description: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.description,
+                                                    user_id: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.id_str,
+                                                    scr_name: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.screen_name,
+                                                    all_tweet_count: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.statuses_count,
+                                                    is_blue:media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.is_blue_verified,
+                                                    location: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.location,
+                                                    account_create_date: media_info_obj[index].additional_media_info?.source_user?.user_results?.result?.legacy?.created_at
+                                                }
                                             }
                                         }
+                                        const media_info = {
+                                            type: media_info_obj[index].type,
+                                            duration_ms: media_info_obj[index].video_info.duration_millis,
+                                            video_raw: media_info_obj[index].video_info.variants.at(-1),
+                                            video_source_user_info:media_source_user_data
+                                        }
+                                        video_info.push(media_info);
                                     }
-                                    const media_info = {
-                                        type: media_info_obj[index].type,
-                                        duration_ms: media_info_obj[index].video_info.duration_millis,
-                                        video_raw: media_info_obj[index].video_info.variants.at(-1),
-                                        video_source_user_info:media_source_user_data
+                                    if(media_info_obj[index].type == "animated_gif"){
+                                        const media_info = {
+                                            type: media_info_obj[index].type,
+                                            duration_ms: null,
+                                            video_raw: media_info_obj[index].video_info.variants.at(-1),
+                                            video_source_user_info: null
+                                        }
+                                        video_info.push(media_info);
                                     }
-                                    video_info.push(media_info);
                                 }
-                                if(media_info_obj[index].type == "animated_gif"){
-                                    const media_info = {
-                                        type: media_info_obj[index].type,
-                                        duration_ms: null,
-                                        video_raw: media_info_obj[index].video_info.variants.at(-1),
-                                        video_source_user_info: null
-                                    }
-                                    video_info.push(media_info);
+                                if(video_info.length == 0){
+                                    video_info = null;
                                 }
-                            }
-                            if(video_info.length == 0){
+                            }else{
                                 video_info = null;
                             }
-                        }else{
-                            video_info = null;
-                        }
-                        //ツイート情報オブジェクト生成
-                        const report_urlparam = `client_location=community:ranked:suggest_community_tweet&client_referer=${window.location.pathname}&client_app_id=3033300&source=reporttweet&report_flow_id=%cslt_random_uuid%&reported_user_id=${tweet_info_communities.user.id_str}&reported_tweet_id=${tweet_info_communities.id_str}&initiated_in_app=1&lang=ja`;
-                        const user_report_json_body = `{\"input_flow_data\":{\"requested_variant\":\"{\\\"client_app_id\\\":\\\"3033300\\\",\\\"client_location\\\":\\\"profile:header:\\\",\\\"client_referer\\\":\\\"/${tweet_info_communities.user.screen_name}\\\",\\\"is_media\\\":false,\\\"is_promoted\\\":false,\\\"report_flow_id\\\":\\\"%cslt_random_uuid%\\\",\\\"reported_user_id\\\":\\\"${tweet_info_communities.user.id_str}\\\",\\\"source\\\":\\\"reportprofile\\\"}\",\"flow_context\":{\"debug_overrides\":{},\"start_location\":{\"location\":\"profile\",\"profile\":{\"profile_id\":\"${tweet_info_communities.user.id_str}\"}}}}}`;
-                        let is_reply_communities = false;
-                        let reply_user_data_communities_obj = null;
-                        let communities_twitter_card_obj = null;
-                        let communities_twitter_card_unified_obj = null;
-                        let communities_out_urls = null;
-                        if(tweet_info_communities?.in_reply_to_status_id_str != undefined){
-                            is_reply_communities = true;
-                            reply_user_data_communities_obj = {
-                                name: tweet_info_communities?.in_reply_to_user.name, 
-                                user_id: tweet_info_communities?.in_reply_to_user.id_str,
-                                scr_name: tweet_info_communities?.in_reply_to_user.screen_name,
-                                all_tweet_count: tweet_info_communities?.in_reply_to_user.statuses_count,
-                                is_blue: tweet_info_communities?.in_reply_to_user.is_blue_verified,
-                                location: tweet_info_communities?.in_reply_to_user.location,
-                                account_create_date: tweet_info_communities?.in_reply_to_user.created_at
+                            //ツイート情報オブジェクト生成
+                            const report_urlparam = `client_location=community:ranked:suggest_community_tweet&client_referer=${window.location.pathname}&client_app_id=3033300&source=reporttweet&report_flow_id=%cslt_random_uuid%&reported_user_id=${tweet_info_communities.user.id_str}&reported_tweet_id=${tweet_info_communities.id_str}&initiated_in_app=1&lang=ja`;
+                            const user_report_json_body = `{\"input_flow_data\":{\"requested_variant\":\"{\\\"client_app_id\\\":\\\"3033300\\\",\\\"client_location\\\":\\\"profile:header:\\\",\\\"client_referer\\\":\\\"/${tweet_info_communities.user.screen_name}\\\",\\\"is_media\\\":false,\\\"is_promoted\\\":false,\\\"report_flow_id\\\":\\\"%cslt_random_uuid%\\\",\\\"reported_user_id\\\":\\\"${tweet_info_communities.user.id_str}\\\",\\\"source\\\":\\\"reportprofile\\\"}\",\"flow_context\":{\"debug_overrides\":{},\"start_location\":{\"location\":\"profile\",\"profile\":{\"profile_id\":\"${tweet_info_communities.user.id_str}\"}}}}}`;
+                            let is_reply_communities = false;
+                            let reply_user_data_communities_obj = null;
+                            let communities_twitter_card_obj = null;
+                            let communities_twitter_card_unified_obj = null;
+                            let communities_out_urls = null;
+                            if(tweet_info_communities?.in_reply_to_status_id_str != undefined){
+                                is_reply_communities = true;
+                                reply_user_data_communities_obj = {
+                                    name: tweet_info_communities?.in_reply_to_user.name, 
+                                    user_id: tweet_info_communities?.in_reply_to_user.id_str,
+                                    scr_name: tweet_info_communities?.in_reply_to_user.screen_name,
+                                    all_tweet_count: tweet_info_communities?.in_reply_to_user.statuses_count,
+                                    is_blue: tweet_info_communities?.in_reply_to_user.is_blue_verified,
+                                    location: tweet_info_communities?.in_reply_to_user.location,
+                                    account_create_date: tweet_info_communities?.in_reply_to_user.created_at
+                                }
+                            }
+                            if(tweet_info_communities?.card?.binding_values?.domain?.string_value != undefined){
+                                communities_twitter_card_obj = {
+                                    domain: tweet_info_communities?.card.binding_values.domain.string_value
+                                }
+                            }
+                            if(tweet_info_communities?.card?.binding_values?.unified_card?.string_value){
+                                communities_twitter_card_unified_obj = JSON.parse(tweet_info_communities?.card?.binding_values?.unified_card?.string_value)
+                            }
+                            if(tweet_info_communities?.entities?.urls?.length != 0){
+                                communities_out_urls = tweet_info_communities?.entities.urls;
+                            }
+                            const tweetinfo_attr_communities = {
+                                is_root_tweet: false,
+                                mentions: tweet_info_communities?.entities?.user_mentions ?? null,
+                                text: tweet_info_communities?.text,
+                                tweet_id: tweet_info_communities?.id_str, 
+                                tweet_client: tweet_info_communities?.source_name,
+                                is_promoted: is_promo_tweet,
+                                is_reply: is_reply_communities,
+                                is_user_data_only: false,
+                                grok_share_attachment: tweet_info_communities?.grok_share_attachment ?? null,
+                                content_disclosure: tweet_info_communities?.content_disclosure ?? null,
+                                user_data:{
+                                    name: tweet_info_communities?.user.name, 
+                                    user_id: tweet_info_communities?.user.id_str,
+                                    scr_name: tweet_info_communities?.user.screen_name,
+                                    all_tweet_count: tweet_info_communities?.user.statuses_count,
+                                    is_blue: tweet_info_communities?.user.is_blue_verified,
+                                    location: tweet_info_communities?.user.location,
+                                    account_create_date: tweet_info_communities?.user.created_at
+                                },
+                                in_reply_user_data: reply_user_data_communities_obj,
+                                tweet_video_info: video_info,
+                                report_param: report_urlparam,
+                                user_report_json: user_report_json_body,
+                                "tw_card_obj": communities_twitter_card_obj,
+                                "tw_card_unified_obj": communities_twitter_card_unified_obj,
+                                "attached_urls": communities_out_urls,
+                            };
+                            const target_root_elem_communities = tweet_elem[tweet_index].closest('[data-testid="cellInnerDiv"]');
+                            target_root_elem_communities.setAttribute("cslt_tweet_info", JSON.stringify(tweetinfo_attr_communities));
+                            //フォロー済フラグ付加
+                            if(tweet_info_communities?.user.following){
+                                target_root_elem_communities.setAttribute("cslt_tweet_info_following_flag", "true");
+                            }
+                            //自分のツイートフラグ付加
+                            if(login_userid() == tweet_info_communities?.user.screen_name){
+                                target_root_elem_communities.setAttribute("cslt_tweet_info_mytweet_flag", "true");
+                            }
+                            //Blue認証付きフラグ
+                            if(tweet_info_communities?.user.is_blue_verified){
+                                target_root_elem_communities.setAttribute("cslt_tweet_info_isblue_flag", "true");
                             }
                         }
-                        if(tweet_info_communities?.card?.binding_values?.domain?.string_value != undefined){
-                            communities_twitter_card_obj = {
-                                domain: tweet_info_communities?.card.binding_values.domain.string_value
-                            }
-                        }
-                        if(tweet_info_communities?.card?.binding_values?.unified_card?.string_value){
-                            communities_twitter_card_unified_obj = JSON.parse(tweet_info_communities?.card?.binding_values?.unified_card?.string_value)
-                        }
-                        if(tweet_info_communities?.entities?.urls?.length != 0){
-                            communities_out_urls = tweet_info_communities?.entities.urls;
-                        }
-                        const tweetinfo_attr_communities = {
-                            is_root_tweet: false,
-                            mentions: tweet_info_communities?.entities?.user_mentions ?? null,
-                            text: tweet_info_communities?.text,
-                            tweet_id: tweet_info_communities?.id_str, 
-                            tweet_client: tweet_info_communities?.source_name,
-                            is_promoted: is_promo_tweet,
-                            is_reply: is_reply_communities,
-                            is_user_data_only: false,
-                            grok_share_attachment: tweet_info_communities?.grok_share_attachment ?? null,
-                            content_disclosure: tweet_info_communities?.content_disclosure ?? null,
-                            user_data:{
-                                name: tweet_info_communities?.user.name, 
-                                user_id: tweet_info_communities?.user.id_str,
-                                scr_name: tweet_info_communities?.user.screen_name,
-                                all_tweet_count: tweet_info_communities?.user.statuses_count,
-                                is_blue: tweet_info_communities?.user.is_blue_verified,
-                                location: tweet_info_communities?.user.location,
-                                account_create_date: tweet_info_communities?.user.created_at
-                            },
-                            in_reply_user_data: reply_user_data_communities_obj,
-                            tweet_video_info: video_info,
-                            report_param: report_urlparam,
-                            user_report_json: user_report_json_body,
-                            "tw_card_obj": communities_twitter_card_obj,
-                            "tw_card_unified_obj": communities_twitter_card_unified_obj,
-                            "attached_urls": communities_out_urls,
-                        };
-                        const target_root_elem_communities = tweet_elem[tweet_index].closest('[data-testid="cellInnerDiv"]');
-                        target_root_elem_communities.setAttribute("cslt_tweet_info", JSON.stringify(tweetinfo_attr_communities));
-                        //フォロー済フラグ付加
-                        if(tweet_info_communities?.user.following){
-                            target_root_elem_communities.setAttribute("cslt_tweet_info_following_flag", "true");
-                        }
-                        //自分のツイートフラグ付加
-                        if(login_userid() == tweet_info_communities?.user.screen_name){
-                            target_root_elem_communities.setAttribute("cslt_tweet_info_mytweet_flag", "true");
-                        }
-                        //Blue認証付きフラグ
-                        if(tweet_info_communities?.user.is_blue_verified){
-                            target_root_elem_communities.setAttribute("cslt_tweet_info_isblue_flag", "true");
-                        }
-                    }
-                    break;
-                case 'settings_block_mute':
-                    const block_mute_list_userid = get_tw_userdata(tweet_elem[tweet_index], "settings_block_mute_user_id");
-                    tweet_elem[tweet_index].setAttribute("cslt_block_mute_list_user_id", block_mute_list_userid);
-                    //console.log(block_mute_list_userid)
-                    break;
-                default:
-                    tweet_elem[tweet_index].closest('[data-testid="cellInnerDiv"]').setAttribute("cslt_tweet_info", JSON.stringify({status:null}));
-                    break;
+                        break;
+                    case 'settings_block_mute':
+                        const block_mute_list_userid = get_tw_userdata(tweet_elem[tweet_index], "settings_block_mute_user_id");
+                        tweet_elem[tweet_index].setAttribute("cslt_block_mute_list_user_id", block_mute_list_userid);
+                        //console.log(block_mute_list_userid)
+                        break;
+                    default:
+                        tweet_elem[tweet_index].closest('[data-testid="cellInnerDiv"]').setAttribute("cslt_tweet_info", JSON.stringify({status:null}));
+                        break;
+                }
+                tweet_elem[tweet_index].setAttribute("cslt_tweet_process", "ok");
+            }else{
+                tweet_elem[tweet_index].setAttribute("cslt_tweet_process", "ok");
             }
-            tweet_elem[tweet_index].setAttribute("cslt_tweet_process", "ok");
-        }else{
-            tweet_elem[tweet_index].setAttribute("cslt_tweet_process", "ok");
+
         }
-        
-    }
-});
-tweet_obs.observe(root_elem, {
-    childList: true,
-    subtree: true
-});
+    });
+    tweet_obs.observe(root_elem, {
+        childList: true,
+        subtree: true
+    });
+})();

--- a/cslt_tweet_ctrl.js
+++ b/cslt_tweet_ctrl.js
@@ -203,14 +203,26 @@
                             }
                             if(tweet_info_reply.in_reply_to_status_id_str != undefined){
                                 is_reply_status = true;
-                                reply_user_data_status_obj = {
-                                    name: tweet_info_reply.in_reply_to_user.name, 
-                                    user_id: tweet_info_reply.in_reply_to_user.id_str,
-                                    scr_name: tweet_info_reply.in_reply_to_user.screen_name,
-                                    all_tweet_count: tweet_info_reply.in_reply_to_user.statuses_count,
-                                    is_blue:tweet_info_reply.in_reply_to_user.is_blue_verified,
-                                    location: tweet_info_reply.in_reply_to_user.location,
-                                    account_create_date: tweet_info_reply.in_reply_to_user.created_at
+                                if(tweet_info_reply?.in_reply_to_user){
+                                    reply_user_data_status_obj = {
+                                        name: tweet_info_reply?.in_reply_to_user.name, 
+                                        user_id: tweet_info_reply?.in_reply_to_user.id_str,
+                                        scr_name: tweet_info_reply?.in_reply_to_user.screen_name,
+                                        all_tweet_count: tweet_info_reply?.in_reply_to_user.statuses_count,
+                                        is_blue:tweet_info_reply?.in_reply_to_user.is_blue_verified,
+                                        location: tweet_info_reply?.in_reply_to_user.location,
+                                        account_create_date: tweet_info_reply?.in_reply_to_user.created_at
+                                    }
+                                }else{
+                                    reply_user_data_status_obj = {
+                                        name: null, 
+                                        user_id: tweet_info_reply?.in_reply_to_status_id_str,
+                                        scr_name: tweet_info_reply?.in_reply_to_screen_name,
+                                        all_tweet_count: null,
+                                        is_blue:null,
+                                        location: null,
+                                        account_create_date: null
+                                    }
                                 }
                             }
                             if(tweet_info_reply?.card?.binding_values?.domain?.string_value != undefined){

--- a/cslt_tweet_ctrl.js
+++ b/cslt_tweet_ctrl.js
@@ -1,6 +1,7 @@
 (function (){
     //新しいクライアント上で動作させているかを検出する
-    if (window.__TSR_ROUTER__){
+    const isNewClient = !!window.__TSR_ROUTER__ || !document.getElementById('react-root');
+    if (isNewClient){
         console.log("Use new client");
         return;
     };

--- a/cslt_tweet_ctrl_relay.js
+++ b/cslt_tweet_ctrl_relay.js
@@ -976,7 +976,7 @@
     const closeFlag = localStorage.getItem("cslt_2607_ref_msg_read");
     if (closeFlag === "true") return;
 
-    class ExtBanner extends HTMLElement {
+    class CsltCompatibleModeUserMessage extends HTMLElement {
       constructor() {
         super();
         this.alive = true;
@@ -1031,7 +1031,7 @@
       }
     }
 
-    customElements.define("ext-banner", ExtBanner);
-    document.body.prepend(new ExtBanner());
+    customElements.define("cslt-compatible-message-banner", CsltCompatibleModeUserMessage);
+    document.body.prepend(new CsltCompatibleModeUserMessage());
   }
 })();

--- a/cslt_tweet_ctrl_relay.js
+++ b/cslt_tweet_ctrl_relay.js
@@ -1,0 +1,1037 @@
+/* 新クライアント向け投稿情報抽出 
+非ログイン状態のクライアントを調査するしか私に出来る手がなかった...
+調査と憶測で頑張って書いてみたが、これでログイン後に動くかわからない...
+*/
+
+(function () {
+  //新しいクライアント上で動作させているかを検出する
+  if (!window.__TSR_ROUTER__) {
+    console.log("Use old client");
+    return;
+  }
+  console.log("CSLT Relay Analyze Script is Working!");
+
+  //ユーザーに本モードで動作していることを通知(実装完了後に削除する)
+  setCompatibleModeUserMessage();
+
+  /* React Relay Environment 取得 */
+
+  //Relay Environmentキャッシュ
+  let _env = null;
+
+  //ReactFiber取得
+  function getFiber(element) {
+    const key = Object.keys(element).find((k) => k.startsWith("__reactFiber$"));
+    return key ? element[key] : null;
+  }
+
+  //Fiberの中からRelay Environmentを取得する
+  function findRelayEnv(obj, depth = 0, visited = new WeakSet()) {
+    // 捜索の深さ6超えか、循環参照なら取得を打ち切る
+    if (!obj || typeof obj !== "object" || depth > 6 || visited.has(obj))
+      return null;
+
+    visited.add(obj);
+
+    if (typeof obj.getStore === "function" && typeof obj.lookup === "function")
+      return obj;
+
+    for (const key of Object.keys(obj)) {
+      try {
+        //子プロパティを再帰で探索する
+        const found = findRelayEnv(obj[key], depth + 1, visited);
+        if (found) return found;
+      } catch {}
+    }
+    return null;
+  }
+
+  //Relay Environmentを取得する
+  function getRelayEnv() {
+    //キャッシュ済みならそのまま返す
+    if (_env) return _env;
+
+    //Fiberを探る対象を指定
+    const rootTargets = [
+      document.querySelector("main"),
+      document.getElementById("react-root"),
+      document.body,
+    ];
+
+    for (const target of rootTargets) {
+      if (!target) continue;
+
+      // DOM要素からFiberを取得
+      let fiberNode = getFiber(target);
+
+      while (fiberNode) {
+        //Fiberの props/state/インスタンスの中を探す
+        for (const propsSource of [
+          fiberNode.memoizedProps,
+          fiberNode.memoizedState,
+          fiberNode.stateNode,
+        ]) {
+          const found = findRelayEnv(propsSource);
+
+          //見つかったらキャッシュ上で返す
+          if (found) {
+            _env = found;
+            return found;
+          }
+        }
+
+        //親Fiberへ遡る
+        fiberNode = fiberNode.return;
+      }
+    }
+    //見つからなかった場合
+    return null;
+  }
+
+  /* React Relay クエリ参照 */
+
+  //refのIDを使って、Relayストアからレコードを取得する
+  function get(src, ref) {
+    //refが存在しない場合はそのまま返す
+    if (!ref) return ref;
+
+    //__refが存在している場合はストアからレコードを取得する
+    if (ref.__ref) {
+      const resolved = src.get(ref.__ref);
+
+      if (resolved) return resolved;
+
+      return null;
+    }
+
+    //クエリ参照でなければそのまま返す
+    return ref;
+  }
+
+  //複数のrefのIDを使って、ストアからレコードを取得する
+  function getRefs(src, field) {
+    //fieldが無い、または__refs配列を持っていなければ空配列
+    if (!field || !Array.isArray(field.__refs)) return [];
+
+    //各IDの参照先をストアから引いて、存在するものだけ返す
+    const results = [];
+    for (const id of field.__refs) {
+      const record = src.get(id);
+
+      if (record) results.push(record);
+    }
+
+    return results;
+  }
+
+  //Relay EnvironmentのStoreからRecordSourceを取得する
+  function getSource() {
+    const store = _env.getStore();
+    return store.getSource();
+  }
+
+  /* 便利関数 */
+
+  //Unix時間からUTC文字列に変換に変換する
+  function msToUTC(ms) {
+    if (!ms) return null;
+
+    return new Date(ms).toUTCString();
+  }
+
+  //画像情報が含まれたオブジェクトからURLを取得
+  function getImgUrl(image) {
+    if (!image) {
+      return null;
+    }
+    if (image.image_url) {
+      return image.image_url;
+    }
+    if (image.url) {
+      return image.url;
+    }
+    if (image.image_url_https) {
+      return image.image_url_https;
+    }
+    return null;
+  }
+
+  /* センシティブ情報レコード取得 */
+
+  // 添付メディアの閲覧注意警告の有無からセンシティブ判定する
+  function isSensitive(src, rec) {
+    const medias = getRefs(src, rec.media_entities2);
+    for (let i = 0; i < medias.length; i++) {
+      const media = medias[i];
+      //警告レコードを取得
+      let warning = get(src, media.sensitive_media_warning);
+
+      //参照でない場合はそのまま
+      if (!warning) {
+        warning = media.sensitive_media_warning;
+      }
+      if (!warning) continue;
+
+      // いずれかの警告フラグが立っていればセンシティブ
+      if (warning.adult_content) return true;
+      if (warning.graphic_violence) return true;
+      if (warning.other) return true;
+    }
+    return false;
+  }
+
+  /* Card周りのオブジェクト取得 */
+
+  function buildCardInfo(src, cardRef) {
+    //カード情報レコードを取得
+    const card = get(src, cardRef);
+    if (!card) return { tw_card_obj: null, tw_card_unified_obj: null };
+
+    //legacyフィールド内を探す
+    const legacy = get(src, card.legacy);
+    if (!legacy) return { tw_card_obj: null, tw_card_unified_obj: null };
+
+    //binding_valuesの配列をオブジェクトに変換
+    const bindings = {};
+    const bindingList = getRefs(src, legacy.binding_values);
+    for (let i = 0; i < bindingList.length; i++) {
+      const binding = bindingList[i];
+
+      // valueレコード取得
+      let value = get(src, binding.value);
+      if (!value) {
+        value = binding.value;
+      }
+
+      //キーまたは値が無ければスキップ
+      if (!value) continue;
+      if (!binding.key) continue;
+
+      if (value.type === "IMAGE") {
+        //画像はさらにvalueレコードを取得する
+        let imageValue = get(src, value.image_value);
+        if (!imageValue) {
+          imageValue = value.image_value;
+        }
+        bindings[binding.key] = imageValue;
+      } else {
+        //画像以外でさらにvalue周りを取得
+        if (value.string_value !== undefined && value.string_value !== null) {
+          bindings[binding.key] = value.string_value;
+        } else if (
+          value.boolean_value !== undefined &&
+          value.boolean_value !== null
+        ) {
+          bindings[binding.key] = value.boolean_value;
+        } else {
+          bindings[binding.key] = value;
+        }
+      }
+    }
+
+    // TwitterCrad周りの情報を取得
+    let tw_card_obj = null;
+    if (bindings.domain) {
+      const domainValue = bindings.domain;
+      // domainが文字列ならそのまま、オブジェクトならstring_valueを取り出す
+      if (typeof domainValue === "string") {
+        tw_card_obj = { domain: domainValue };
+      } else if (domainValue.string_value) {
+        tw_card_obj = { domain: domainValue.string_value };
+      } else {
+        tw_card_obj = { domain: domainValue };
+      }
+    }
+
+    // unified_card周りの情報を取得
+    let tw_card_unified_obj = null;
+    if (bindings.unified_card) {
+      const unifiedCardValue = bindings.unified_card;
+      //文字列ならJSONパースする。オブジェクトならそのまま
+      if (typeof unifiedCardValue === "string") {
+        try {
+          tw_card_unified_obj = JSON.parse(unifiedCardValue);
+        } catch (e) {
+          //壊れたJSONが来ている場合は握りつぶす
+        }
+      } else {
+        tw_card_unified_obj = unifiedCardValue;
+      }
+    }
+
+    return {
+      tw_card_obj: tw_card_obj,
+      tw_card_unified_obj: tw_card_unified_obj,
+    };
+  }
+
+  /* 動画情報を抽出 */
+
+  function buildVideoInfo(src, mediaEntities) {
+    const mediaList = getRefs(src, mediaEntities);
+    if (mediaList.length === 0) return null;
+
+    const result = [];
+    for (let i = 0; i < mediaList.length; i++) {
+      const media = mediaList[i];
+      //動画メタ情報レコードを取得
+      let videoInfo = get(src, media.video_info);
+      if (!videoInfo) {
+        videoInfo = media.video_info;
+      }
+      let type = media.type;
+
+      if (type === "video" && videoInfo) {
+        //動画の投稿元ユーザー情報レコードを取得
+        let sourceUser = null;
+        const additionalMediaInfo = get(src, media.additional_media_info);
+        if (additionalMediaInfo) {
+          //動画の作成元情報レコードを取得
+          const sourceUserRef = get(src, additionalMediaInfo.source_user);
+          let sourceUserResults = null;
+          if (sourceUserRef) {
+            sourceUserResults = get(src, sourceUserRef.user_results);
+          }
+
+          //作成元ユーザー情報レコードを取得
+          let sourceUserRecord = null;
+          if (sourceUserResults) {
+            sourceUserRecord = get(src, sourceUserResults.result);
+          }
+
+          //ユーザー情報もレコードを取得してまとめる
+          if (sourceUserRecord) {
+            const sourceUserCore = get(src, sourceUserRecord.core);
+            const sourceUserBio = get(src, sourceUserRecord.profile_bio);
+            const sourceUserVerification = get(
+              src,
+              sourceUserRecord.verification,
+            );
+            const sourceUserLocation = get(src, sourceUserRecord.location);
+            sourceUser = {
+              user_data: {
+                name: sourceUserCore ? sourceUserCore.name : null,
+                description: sourceUserBio ? sourceUserBio.description : null,
+                user_id: sourceUserRecord.rest_id,
+                scr_name: sourceUserCore ? sourceUserCore.screen_name : null,
+                all_tweet_count: null,
+                is_blue:
+                  sourceUserVerification &&
+                  sourceUserVerification.is_blue_verified
+                    ? true
+                    : false,
+                location: sourceUserLocation
+                  ? sourceUserLocation.location
+                  : null,
+                account_create_date: null,
+              },
+            };
+          }
+        }
+
+        //解像度情報などを取得
+        const variants = getRefs(src, videoInfo.variants);
+
+        // 最高画質を採用
+        const bestVariant =
+          variants.length > 0 ? variants[variants.length - 1] : null;
+
+        result.push({
+          type: "video",
+          duration_ms: videoInfo.duration_millis,
+          video_raw: bestVariant,
+          video_source_user_info: sourceUser,
+        });
+      } else if (type === "animated_gif") {
+        //GIFの情報を取得
+        let gifVariants = [];
+        if (videoInfo) {
+          gifVariants = getRefs(src, videoInfo.variants);
+        }
+        const bestGifVariant =
+          gifVariants.length > 0 ? gifVariants[gifVariants.length - 1] : null;
+
+        result.push({
+          type: "animated_gif",
+          duration_ms: null,
+          video_raw: bestGifVariant,
+          video_source_user_info: null,
+        });
+      }
+    }
+
+    if (result.length === 0) {
+      return null;
+    }
+    return result;
+  }
+
+  /* ユーザー情報周りのオブジェクト取得 */
+
+  function extractUser(src, rec, userRef) {
+    //ユーザー情報全体のレコードを取得
+    const resolvedUserRef = get(src, userRef);
+    let userResults = null;
+    if (resolvedUserRef && resolvedUserRef.user_results) {
+      userResults = get(src, resolvedUserRef.user_results);
+    }
+
+    //Userレコード本体を取得
+    let userRecord = null;
+    if (userResults && userResults.result) {
+      userRecord = get(src, userResults.result);
+    }
+
+    //ユーザーが見つからない場合
+    if (!userRecord) return { user: null, userData: null };
+
+    /* 各サブフィールドのレコードを取得 */
+
+    //名前/screen_name/作成日時
+    const core = get(src, userRecord.core);
+
+    //認証バッジ情報
+    const verification = get(src, userRecord.verification);
+
+    //ユーザー設定ロケーション
+    const location = get(src, userRecord.location);
+
+    //自己紹介文
+    const bio = get(src, userRecord.profile_bio);
+
+    //ツイート数
+    const tweetCounts = get(src, userRecord.tweet_counts);
+
+    //フォロー/フォロワー数
+    const relationshipCounts = get(src, userRecord.relationship_counts);
+
+    //鍵アカウント情報
+    const privacy = get(src, userRecord.privacy);
+
+    //アイコン画像URLを取得
+    const avatarRef = get(src, userRecord.avatar);
+    const profileImageUrl = getImgUrl(avatarRef);
+
+    //ヘッダー画像URLを取得
+    const bannerRef = get(src, userRecord.banner);
+    const profileBannerUrl = getImgUrl(bannerRef);
+
+    //取得した情報をCSLTで扱えるユーザーオブジェクトにまとめる
+    const userData = {
+      name: core ? core.name : null,
+      description: bio ? bio.description : null,
+      user_id: userRecord.rest_id,
+      scr_name: core ? core.screen_name : null,
+      all_tweet_count:
+        tweetCounts && tweetCounts.tweets !== undefined
+          ? tweetCounts.tweets
+          : null,
+      is_blue: verification && verification.is_blue_verified ? true : false,
+      location: location ? location.location : null,
+      account_create_date: core ? msToUTC(core.created_at_ms) : null,
+      possibly_sensitive:
+        userRecord.possibly_sensitive !== undefined
+          ? userRecord.possibly_sensitive
+          : null,
+      protected: privacy && privacy.protected ? true : false,
+      followers_count:
+        relationshipCounts && relationshipCounts.followers !== undefined
+          ? relationshipCounts.followers
+          : null,
+      friends_count:
+        relationshipCounts && relationshipCounts.following !== undefined
+          ? relationshipCounts.following
+          : null,
+      profile_image_url_https: profileImageUrl,
+      profile_banner_url: profileBannerUrl,
+      // 現時点で取得不能(将来ストアから取れるようになったら実装する)
+      blocked_by: null,
+      // ログイン時のみ値が入るはず...
+      following:
+        userRecord.is_following !== undefined ? userRecord.is_following : null,
+    };
+
+    return {
+      user: userRecord,
+      userData: userData,
+    };
+  }
+
+  /* 報告用JSON生成 */
+
+  function buildReportJson(
+    rec,
+    userId,
+    screenName,
+    permalink,
+    isMedia,
+    isPromoted,
+  ) {
+    //投稿の報告用
+    const requestedVariant = {
+      client_app_id: "3033300",
+      client_location: "tweet:conversation_descendants:tweet",
+      client_referer: permalink || "",
+      is_media: isMedia,
+      is_promoted: isPromoted,
+      report_flow_id: "%cslt_random_uuid%",
+      reported_tweet_id: rec.rest_id,
+      reported_user_id: userId,
+      source: "reporttweet",
+    };
+
+    const payload = {
+      input_flow_data: {
+        requested_variant: JSON.stringify(requestedVariant),
+        flow_context: {
+          debug_overrides: {},
+          start_location: {
+            location: "tweet",
+            tweet: { tweet_id: rec.rest_id },
+          },
+        },
+      },
+    };
+    return JSON.stringify(payload);
+  }
+
+  function buildUserReportJson(userId, screenName) {
+    //ユーザーの報告用
+    const requestedVariant = {
+      client_app_id: "3033300",
+      client_location: "profile:header:",
+      client_referer: `/${screenName}`,
+      is_media: false,
+      is_promoted: false,
+      report_flow_id: "%cslt_random_uuid%",
+      reported_user_id: userId,
+      source: "reportprofile",
+    };
+    const payload = {
+      input_flow_data: {
+        requested_variant: JSON.stringify(requestedVariant),
+        flow_context: {
+          debug_overrides: {},
+          start_location: {
+            location: "profile",
+            profile: { profile_id: userId },
+          },
+        },
+      },
+    };
+    return JSON.stringify(payload);
+  }
+
+  /* 投稿情報取得 */
+
+  function toLegacyFormat(src, rec) {
+    if (!rec) return null;
+
+    //ツイート詳細レコードを取得
+    let details = get(src, rec.details);
+    if (!details) {
+      details = {};
+    }
+
+    //ユーザー情報を取り出す
+    const extracted = extractUser(src, rec, rec.core);
+    const user = extracted.user;
+    const userData = extracted.userData;
+
+    //本文テキスト取得
+    //長文ツイート(note_tweet)があればそちらを優先
+    let text = details.full_text; //デフォルトは通常のfull_text
+    const note = get(src, rec.note_tweet);
+    if (note) {
+      const noteResults = get(src, note.note_tweet_results);
+      if (noteResults && noteResults.result) {
+        const noteData = get(src, noteResults.result);
+        if (noteData && noteData.text) {
+          // 長文があればそちらを使う
+          text = noteData.text;
+        }
+      }
+    }
+
+    //TwitterCardなどの情報を取得
+    const cardInfo = buildCardInfo(src, rec.card);
+
+    //本文中のURL一覧を取得
+    const urls = getRefs(src, rec.url_entities);
+
+    //引用の情報を取得
+    let quoted_obj = null;
+    if (rec.quoted_tweet_results) {
+      // 引用の情報を取得する
+      const quotedTweetResults = get(src, rec.quoted_tweet_results);
+      let quotedResult = null;
+      if (quotedTweetResults) {
+        quotedResult = get(src, quotedTweetResults.result);
+      }
+
+      //引用の可視情報を取得
+      let quotedTweet = quotedResult;
+      if (
+        quotedResult &&
+        quotedResult.__typename === "TweetWithVisibilityResults"
+      ) {
+        quotedTweet = get(src, quotedResult.tweet);
+      }
+
+      //引用情報を従来の形式に変換
+      if (quotedTweet && quotedTweet.__typename === "Tweet") {
+        const quotedInfo = toLegacyFormat(src, quotedTweet);
+        if (quotedInfo) {
+          quoted_obj = {
+            text: quotedInfo.text,
+            mentions: quotedInfo.mentions,
+            possibly_sensitive: quotedInfo.possibly_sensitive,
+            possibly_sensitive_editable: false,
+            quoted_urls: quotedInfo.attached_urls,
+            tweet_lang: quotedInfo.tweet_lang,
+            content_disclosure: quotedInfo.content_disclosure,
+            user_data: quotedInfo.user_data,
+          };
+        }
+      }
+    }
+
+    //メディア添付があるか
+    const isMedia = getRefs(src, rec.media_entities2).length > 0;
+
+    //広告の投稿を検出する
+    const isPromoted = promotedSet.has(rec.rest_id);
+
+    // ツイートへのパーマリンクパス
+    let permalink = null;
+    if (userData) {
+      permalink = `/${userData.scr_name}/status/${rec.rest_id}`;
+    }
+
+    //報告用のユーザー情報
+    const reportUserId = userData && userData.user_id ? userData.user_id : "";
+    const reportScreenName =
+      userData && userData.scr_name ? userData.scr_name : "";
+
+    //コミュニティノート等の情報
+    let contentDisclosure = get(src, rec.content_disclosure);
+    if (!contentDisclosure) {
+      contentDisclosure = null;
+    }
+
+    return {
+      is_root_tweet: permalink === location.pathname,
+      mentions: getRefs(src, rec.mention_entities),
+      text: text,
+      tweet_id: rec.rest_id,
+      //現時点で取得不能(将来ストアから取れるようになったら取得できるようにする)
+      tweet_client: null,
+      is_reply: rec.reply_to_results ? true : false,
+      is_user_data_only: false,
+      //現時点で取得不能(同上)
+      tweet_lang: null,
+      is_promoted: isPromoted,
+      grok_share_attachment: rec.grok_share_attachment
+        ? rec.grok_share_attachment
+        : null,
+      content_disclosure: contentDisclosure,
+      //メディアの警告フラグから判定する
+      possibly_sensitive: isSensitive(src, rec),
+      user_data: userData,
+      tweet_video_info: buildVideoInfo(src, rec.media_entities2),
+      report_json: buildReportJson(
+        rec,
+        reportUserId,
+        reportScreenName,
+        permalink,
+        isMedia,
+        isPromoted,
+      ),
+      user_report_json: buildUserReportJson(reportUserId, reportScreenName),
+      quoted_obj: quoted_obj,
+      tw_card_obj: cardInfo.tw_card_obj,
+      tw_card_unified_obj: cardInfo.tw_card_unified_obj,
+      attached_urls: urls.length > 0 ? urls : null,
+    };
+  }
+
+  /* ユーザー情報単体を取得(フォロー・フォロワー欄等で使用) */
+  function toUserOnlyFormat(src, userRec) {
+    if (!userRec) return null;
+
+    //ユーザー情報と認証済情報を取得
+    const core = get(src, userRec.core);
+    const verification = get(src, userRec.verification);
+
+    //ユーザーID
+    let userId = userRec.rest_id;
+    if (!userId) {
+      userId = "";
+    }
+
+    //スクリーンネーム
+    let screenName = "";
+    if (core && core.screen_name) {
+      screenName = core.screen_name;
+    }
+
+    //認証付き情報
+    let isBlue = false;
+    if (verification && verification.is_blue_verified) {
+      isBlue = true;
+    }
+
+    return {
+      is_reply: false,
+      is_user_data_only: true,
+      user_data: {
+        name: core ? core.name : null,
+        user_id: userId,
+        scr_name: screenName,
+        all_tweet_count: null,
+        is_blue: isBlue,
+      },
+      report_json: null,
+      user_report_json: buildUserReportJson(userId, screenName),
+    };
+  }
+
+  /* プロモーションの投稿のIDを収集する */
+  const promotedSet = new Set();
+
+  //promoted_metadataを持つレコードからプロモツイートのIDを収集する
+  function collectPromotedIds() {
+    if (!_env) return;
+    const src = getSource();
+
+    //ストア内の全レコードIDを列挙
+    let ids;
+    if (src.getRecordIDs) {
+      ids = src.getRecordIDs();
+    } else {
+      ids = Object.keys(src.toJSON());
+    }
+
+    for (let i = 0; i < ids.length; i++) {
+      const rec = src.get(ids[i]);
+      if (!rec) continue;
+      if (!rec.promoted_metadata) continue;
+
+      //promoted_metadataを持つレコードからツイートIDを辿って収集する
+      const tweetResults = get(src, rec.tweet_results);
+      if (!tweetResults) continue;
+
+      const tweetRecord = get(src, tweetResults.result);
+      if (tweetRecord && tweetRecord.rest_id) {
+        promotedSet.add(tweetRecord.rest_id);
+      }
+    }
+  }
+
+  //ツイートIDからストアのレコードを直接引いて従来形式の情報オブジェクトを返す
+  function lookupTweet(tweetId) {
+    if (!_env) return null;
+
+    try {
+      const src = getSource();
+
+      //TweetResultsからツイートレコードを引く
+      const tweetResults = src.get("TweetResults:" + tweetId);
+      if (!tweetResults) return null;
+
+      const rec = get(src, tweetResults.result);
+      if (!rec) return null;
+      if (rec.__typename !== "Tweet") return null;
+
+      return toLegacyFormat(src, rec);
+    } catch (e) {
+      //取得失敗時は無視
+    }
+    return null;
+  }
+
+  /* DOMからでしか取れない情報を取得 */
+  //ツイートのDOMにあるFiberからツイートIDを探す
+  function getTweetId(element) {
+    const fiber = getFiber(element);
+    if (!fiber) return null;
+
+    const key = fiber.memoizedProps?.children?.key;
+    if (!key) return null;
+
+    if (!key.startsWith("tweet-")) return null;
+
+    return key.replace("tweet-", "");
+  }
+
+  /* ログインユーザー情報を取得 */
+  // undefined=未解決, null=解決したが取得できず
+  let _myScreenName;
+  let _myUserId;
+
+  function resolveLoginIdentity() {
+    //解決済みなら何もしない
+    if (_myScreenName !== undefined) return;
+
+    _myScreenName = null;
+    _myUserId = null;
+
+    /* 
+    予備実装。
+    非ログイン状態でしか調査できていないため、ここの辺りは動かないと思われる...
+    TODO:本格的に展開された後に調査して実装する
+    */
+    //初期化スクリプトからscreen_nameを取得
+    try {
+        //このセレクタは従来のもののため、新しいものでは確実に動かないと思われる
+      const script = document.querySelector(
+        'script[type="text/javascript"][charset="utf-8"][nonce]',
+      );
+      if (script) {
+        const match = script.textContent.match(/"screen_name":"(.*?)"/);
+        if (match) {
+          _myScreenName = match[1];
+        }
+      }
+    } catch (e) {
+      //取得失敗は無視
+    }
+
+    //cookieからユーザーIDを取得（screen_nameが取れなかった場合の代替手段）
+    try {
+      const cookieMatch = document.cookie.match(/twid=u%3D(\d+)/);
+      if (cookieMatch) {
+        _myUserId = cookieMatch[1];
+      }
+    } catch (e) {
+      // 取得失敗は無視
+    }
+  }
+
+  //自分のツイートか判定する
+  function isOwnTweet(userData) {
+    resolveLoginIdentity();
+    // screen_name で一致判定
+    if (_myScreenName && userData && userData.scr_name === _myScreenName) {
+      return true;
+    }
+    // user_id で一致判定（screen_nameが取れなかった場合用）
+    if (_myUserId && userData && userData.user_id === _myUserId) {
+      return true;
+    }
+    return false;
+  }
+
+  // 投稿などのデータをJSON文字列で属性に埋め込む
+  function attachTweetInfo(element, info) {
+    element.setAttribute("cslt_tweet_info", JSON.stringify(info));
+
+    // フォロー中フラグ
+    if (info.user_data && info.user_data.following) {
+      element.setAttribute("cslt_tweet_info_following_flag", "true");
+    }
+    // 自分のツイートフラグ
+    if (isOwnTweet(info.user_data)) {
+      element.setAttribute("cslt_tweet_info_mytweet_flag", "true");
+    }
+    // Blueバッジフラグ
+    if (info.user_data && info.user_data.is_blue) {
+      element.setAttribute("cslt_tweet_info_isblue_flag", "true");
+    }
+  }
+
+  //表示されているツイートから各種情報を取得して各DOM属性に情報を埋め込む
+  function processArticles() {
+    if (!_env) return;
+
+    //プロモツイートIDを収集
+    collectPromotedIds();
+
+    //レンダリングされた未処理の投稿をまとめて取得する
+    const tweets = document.querySelectorAll(
+      "div[itemscope] ul li:not([cslt_tweet_info])",
+    );
+    for (let i = 0; i < tweets.length; i++) {
+      const tweet = tweets[i];
+
+      const tweetId = getTweetId(tweet);
+      if (!tweetId) continue;
+
+      const info = lookupTweet(tweetId);
+      if (info) {
+        attachTweetInfo(tweet, info);
+      }
+    }
+
+    /* ユーザーページの処理 */
+    //未処理のヘッダーを探す
+    const userHeader = document.querySelector(
+      'div[itemprop="mainEntity"]:not([cslt_user_page_info_element])',
+    );
+    if (!userHeader) return;
+    if (!_env) return;
+
+    // URLからスクリーンネームを取得
+    const screenName = location.pathname.split("/")[1];
+    if (!screenName) return;
+
+    const src = getSource();
+    let ids;
+    if (src.getRecordIDs) {
+      ids = src.getRecordIDs();
+    } else {
+      ids = [];
+    }
+
+    // 該当ユーザーを検索する
+    for (let i = 0; i < ids.length; i++) {
+      const rec = src.get(ids[i]);
+      if (!rec) continue;
+      if (rec.__typename !== "User") continue;
+
+      const core = get(src, rec.core);
+      if (!core) continue;
+
+      // スクリーンネームが一致するUserレコードがあった場合
+      if (core.screen_name !== screenName) continue;
+
+      const formatted = toUserOnlyFormat(src, rec);
+      if (formatted) {
+        // ユーザー情報を属性に埋め込む
+        userHeader.setAttribute(
+          "cslt_tweet_info",
+          JSON.stringify({ user_data_array: [formatted] }),
+        );
+        userHeader.setAttribute("cslt_user_page_user_scr_name", screenName);
+
+        // 処理済みフラグ
+        userHeader.setAttribute("cslt_user_page_info_element", "");
+      }
+      break;
+    }
+  }
+
+  /* 情報抽出機能を起動する */
+  let _processScheduled = false;
+  let _ready = false;
+  let _retries = 0;
+
+  //起動
+  function boot() {
+    // Relay Environmentを探す
+    const env = getRelayEnv();
+    if (!env) {
+      return false;
+    }
+
+    _ready = true;
+
+    //起動時点で既にストアにあるプロモツイートIDを収集
+    collectPromotedIds();
+
+    processArticles();
+
+    console.log("CSLT Relay Adapter: Ready");
+    return true;
+  }
+
+  //Relay Environmentが見つかるまで起動をリトライ
+  function tryBoot() {
+    _retries++;
+    //見つかったら終了
+    if (boot()) return;
+    //40回リトライしても見つからなければ諦める
+    if (_retries > 40) {
+      console.warn("CSLT Relay Adapter: Relay Environment not found");
+      return;
+    }
+
+    //まだ見つからなければ次のリトライを予約
+    setTimeout(tryBoot, 500);
+  }
+  setTimeout(tryBoot, 500);
+
+  const mutationObserver = new MutationObserver(function () {
+    // Relay Environmentがまだ見つかっていなければ何もしない
+    if (!_ready) return;
+
+    // 既に次フレームでの実行が予約済みならスキップ
+    if (_processScheduled) return;
+    _processScheduled = true;
+
+    //1フレームにつき最大1回だけ抽出を行う
+    requestAnimationFrame(function () {
+      _processScheduled = false;
+      processArticles();
+    });
+  });
+  // ターゲットのDOM変更を監視
+  mutationObserver.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+
+  //本モード動作中メッセージ表示(完全な実装後に消す)
+  function setCompatibleModeUserMessage() {
+    const closeFlag = localStorage.getItem("cslt_2607_ref_msg_read");
+    if (closeFlag === "true") return;
+
+    class ExtBanner extends HTMLElement {
+      constructor() {
+        super();
+        this.alive = true;
+        const shadow = this.attachShadow({ mode: "closed" });
+
+        const style = document.createElement("style");
+        style.textContent = `
+      :host {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+        width: 100%;
+        padding: 8px;
+        background: #ffeb3b66;
+        font-size: 14px;
+        font-family: sans-serif;
+        box-sizing: border-box;
+      }
+      span {
+        white-space: pre-line;
+      }
+    `;
+
+        const text = document.createElement("div");
+        text.innerHTML = `
+    [CSLT開発者からのメッセージ]
+    <br/>
+    Xの大規模な仕様変更に伴い、 対策用の仮実装モードで動作しています。
+    <br/>
+    一部機能が正常に動作しない場合があります。
+    <br/>
+    現在復旧作業を進めておりますので、今しばらくお待ちください。
+    <br/>
+    <a href="https://github.com/kawa-nobu/Clean-Spam-Link-Tweet/wiki/%E5%A4%A7%E8%A6%8F%E6%A8%A1%E3%81%AA%E4%BB%95%E6%A7%98%E5%A4%89%E6%9B%B4%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6" target="_blank" rel="noopener noreferrer">詳細はこちら<a/>
+    （閉じると次回以降表示されません）`;
+
+        const btn = document.createElement("button");
+        btn.textContent = "閉じる";
+        btn.addEventListener("click", () => {
+          localStorage.setItem("cslt_2607_ref_msg_read", true);
+          this.alive = false;
+          this.remove();
+        });
+
+        shadow.append(style, text, btn);
+      }
+
+      disconnectedCallback() {
+        if (!this.alive) return;
+        setTimeout(() => document.body.prepend(this), 0);
+      }
+    }
+
+    customElements.define("ext-banner", ExtBanner);
+    document.body.prepend(new ExtBanner());
+  }
+})();

--- a/cslt_tweet_ctrl_relay.js
+++ b/cslt_tweet_ctrl_relay.js
@@ -5,7 +5,8 @@
 
 (function () {
   //新しいクライアント上で動作させているかを検出する
-  if (!window.__TSR_ROUTER__) {
+  const isNewClient = !!window.__TSR_ROUTER__ || !document.getElementById('react-root');
+  if (!isNewClient) {
     console.log("Use old client");
     return;
   }

--- a/cslt_tweet_ctrl_relay.js
+++ b/cslt_tweet_ctrl_relay.js
@@ -19,6 +19,15 @@
   //Relay Environmentキャッシュ
   let _env = null;
 
+  //各種ツイートキープレフィックス
+  const TWEET_KEY_PREFIXES = [
+    "tweet-",
+    "promoted-tweet-",
+    "profile-conversation-",
+    "conversationthread-",
+    "tweetdetailrelatedtweets-",
+  ];
+
   //ReactFiber取得
   function getFiber(element) {
     const key = Object.keys(element).find((k) => k.startsWith("__reactFiber$"));
@@ -231,16 +240,12 @@
 
     // TwitterCrad周りの情報を取得
     let tw_card_obj = null;
-    if (bindings.domain) {
-      const domainValue = bindings.domain;
-      // domainが文字列ならそのまま、オブジェクトならstring_valueを取り出す
-      if (typeof domainValue === "string") {
-        tw_card_obj = { domain: domainValue };
-      } else if (domainValue.string_value) {
-        tw_card_obj = { domain: domainValue.string_value };
-      } else {
-        tw_card_obj = { domain: domainValue };
-      }
+    if (bindings) {
+      tw_card_obj = {
+        domain: bindings.domain ?? null,
+        card_url: bindings.card_url ?? null,
+        description: bindings.description ?? null,
+      };
     }
 
     // unified_card周りの情報を取得
@@ -757,11 +762,12 @@
     if (!fiber) return null;
 
     const key = fiber.memoizedProps?.children?.key;
-    if (!key) return null;
+    if (typeof key !== "string") return null;
 
-    if (!key.startsWith("tweet-")) return null;
+    const prefix = TWEET_KEY_PREFIXES.find((p) => key.startsWith(p));
+    if (!prefix) return null;
 
-    return key.replace("tweet-", "");
+    return key.slice(prefix.length);
   }
 
   /* ログインユーザー情報を取得 */
@@ -783,7 +789,7 @@
     */
     //初期化スクリプトからscreen_nameを取得
     try {
-        //このセレクタは従来のもののため、新しいものでは確実に動かないと思われる
+      //このセレクタは従来のもののため、新しいものでは確実に動かないと思われる
       const script = document.querySelector(
         'script[type="text/javascript"][charset="utf-8"][nonce]',
       );
@@ -1031,7 +1037,10 @@
       }
     }
 
-    customElements.define("cslt-compatible-message-banner", CsltCompatibleModeUserMessage);
+    customElements.define(
+      "cslt-compatible-message-banner",
+      CsltCompatibleModeUserMessage,
+    );
     document.body.prepend(new CsltCompatibleModeUserMessage());
   }
 })();

--- a/cslt_tweet_ctrl_relay.js
+++ b/cslt_tweet_ctrl_relay.js
@@ -856,7 +856,7 @@
 
     //レンダリングされた未処理の投稿をまとめて取得する
     const tweets = document.querySelectorAll(
-      "div[itemscope] ul li:not([cslt_tweet_info])",
+      "main div ul li:not([cslt_tweet_info])",
     );
     for (let i = 0; i < tweets.length; i++) {
       const tweet = tweets[i];

--- a/cslt_tweet_ctrl_relay.js
+++ b/cslt_tweet_ctrl_relay.js
@@ -1023,6 +1023,7 @@
 
         const btn = document.createElement("button");
         btn.textContent = "閉じる";
+        btn.style = 'text-wrap-mode: nowrap;';
         btn.addEventListener("click", () => {
           localStorage.setItem("cslt_2607_ref_msg_read", true);
           this.alive = false;

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Clean-Spam-Link-Tweet",
-  "version": "1.9.9.5",
+  "version": "1.9.9.6",
   "manifest_version": 3,
   "description": "ツイート(返信)から悪質なリンクが記載されたツイートを可視化してナイト系スパム等のリンクを踏む事を阻止します。",
   "icons" : {
@@ -12,6 +12,7 @@
   },
   "web_accessible_resources": [{
     "resources": [
+      "cslt_tweet_ctrl_relay.js",
       "cslt_tweet_ctrl.js",
       "filter.json",
       "imp_filter.json",

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -1,6 +1,6 @@
 {
   "name": "Clean-Spam-Link-Tweet",
-  "version": "1.9.9.5",
+  "version": "1.9.9.6",
   "manifest_version": 2,
   "description": "ツイート(返信)から悪質なリンクが記載されたツイートを可視化してナイト系スパム等のリンクを踏む事を阻止します。",
   "icons" : {
@@ -21,6 +21,7 @@
     "default_icon": "icon.png"
   },
   "web_accessible_resources": [
+    "cslt_tweet_ctrl_relay.js",
     "cslt_tweet_ctrl.js",
     "filter.json",
     "imp_filter.json",


### PR DESCRIPTION
## 直したもの
- 返信など一部の投稿で報告ボタンが表示されない問題を修正
- 非表示ユーザー設定で登録された文字を部分一致として処理していた問題を修正
- レガシーURLコピーで失敗する問題を修正

## 関連Issue
- #31 

## 動作確認
- [x] Firefox系のブラウザでも問題なく動作するか
  - Floorp `12.14.2@151.0` で確認

## その他の変更
- Xの新クライアント導入に向けて準備
  - 非ログイン状態の新クライアントで調査を行い実装
    - 新クライアントはログイン状態で公開されていないため、実際に動くかどうかは運次第
  - ほとんどの機能の新クライアント対応を行った
    - 内部仕様変更により、取得できる値が大幅に削減されているため、今後廃止される機能が出るかもしれない\
    - ナイト系スパムなどのマーカー表示類も新旧クライアントで両方動作するように修正した


## マージ後の CSLT バージョン
- `1.9.9.6`

## 雑記(あればご自由にどうぞ)
まずはじめに、Wikiへ投稿したページをご確認下さい。
→ [大規模な仕様変更について](https://github.com/kawa-nobu/Clean-Spam-Link-Tweet/wiki/%E5%A4%A7%E8%A6%8F%E6%A8%A1%E3%81%AA%E4%BB%95%E6%A7%98%E5%A4%89%E6%9B%B4%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)


今回は、これから突如として現れるであろう
X側の新クライアント(画面) への移行に追従する対応を主に行いました。

この新しいクライアントは、
プライベートモードなどログインしていない状態ですでに公開されているもので、
今月中にはログイン後の画面にも本格的に導入されるものと予想しています。

内部の仕組みが今までと大幅に変わっており、
放置したまま移行が始まると確実に動作しなくなるうえ、
そこからの調査にも時間を要することが判明しているため、先手を打って実装しました。

ただ、実際に本格導入が始まったときにこの対応が動作するかどうかは、私にもわかりません。
今できる最善を尽くした形です。

現時点でわかっているのは、
X側の制限によって取得できる値が明らかに減っており、
対スパム性能が落ちてしまうということです。
これは非常に重い問題で、現在も対応策を模索しています。

そのため今回の対応はあくまで障害回避用の仮実装という位置づけで、
調査と実装は今も継続中です。

詳しい様子は #31 をご確認いただければと思います。

#### 作業の時に聞いていた楽曲(覚えている限り)
- Imaginary affair / KOTOKO
  - https://youtu.be/HCrbknMrx7A
- M@STERPIECE / 765PRO ALLSTARS
  - https://youtu.be/VNnciosQYVA
- 知恵と勇気だ!メダロット / 竹内順子
- GROWN KIDZ / SOUL'd OUT
  - https://youtu.be/hoyz6PRmn-Y